### PR TITLE
Fix a bug and update how_to_deploy_audisp_remote_for_audit_log.mkd

### DIFF
--- a/docs/configurations/manual-operation-docs/how_to_deploy_audisp_remote_for_audit_log.mkd
+++ b/docs/configurations/manual-operation-docs/how_to_deploy_audisp_remote_for_audit_log.mkd
@@ -45,10 +45,16 @@ etc/audisp/audisp-remote.conf is inconsistent with the MAN document
 queue_error_action. 
 ```
 
-If not record logs on local filesystem, Modify /etc/audit/auditd.conf:
+If not record logs on local filesystem, Modify /etc/audit/auditd.conf:   
 ```
 write_logs = no
 ```
+
+Set name_format of /etc/audisp/audispd.conf to NUMERIC, in audit.log, the node will record the IP address:   
+```
+name_format = NUMERIC 
+```  
+** Note: The IP address may be 127.0.1.1, please modify it in /etc/hosts. You can use hostname -i to check whether it is the correct address. **    
 
 ### Restart service 
 Restart auditd service:

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -459,7 +459,7 @@ is_kernel_option_enabled() {
 is_a_partition() {
     local PARTITION=$1
     FNRET=128
-    if $(grep "[[:space:]]*${PARTITION}[[:space:]]*" /etc/fstab | grep -vqE "^#"); then
+    if $(grep "[[:space:]]*${PARTITION}[[:space:]].*" /etc/fstab | grep -vqE "^#"); then
         debug "$PARTITION found in fstab"
         FNRET=0
     else


### PR DESCRIPTION
1. Update how_to_deploy_audisp_remote_for_audit_log.mkd.
2. Fix a bug: If /var/log is a separate partition, check whether /var is a separate partition will be passed.