### PR TITLE
Improve typo fixes and polish Mandarin wording

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -1,8 +1,8 @@
 # harbian-audit审计与加固
 
 ## 简介 
-此项目是一个Debian GNU/Linux及CentOS 8及Ubuntu发行版加固的审计工具。主要的测试环境是基于Debian GNU/Linux 9/10/11/12/13及CentOS 8及Ubuntu22，其它版本未充分测试。此项目主要是针对服务器版本，对桌面版本的项没有实现。
-此项目的框架基于[OVH-debian-cis](https://github.com/ovh/debian-cis)，根据Debian GNU/Linux 9的一些特性进行了优化，并根据安全部署合规STIG（[STIG Red_Hat_Enterprise_Linux_7_V2R5](redhat-STIG-DOCs/U_Red_Hat_Enterprise_Linux_7_V2R5_STIG.zip)及[STIG Ubuntu V1R2](https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_Canonical_Ubuntu_16-04_LTS_V1R2_STIG.zip)）及CIS（[cisecurity.org](https://www.cisecurity.org/)）进行了安全检查项的添加，同时也根据HardenedLinux社区就具体生产环境添加了一些安全检查项的审计功能的实现。此项目不仅具有安全项的审计功能，同时也有自动修改的功能。
+本项目是面向 Debian GNU/Linux、CentOS 8 和 Ubuntu 发行版的安全审计与加固工具。当前主要测试环境为 Debian GNU/Linux 9/10/11/12/13、CentOS 8 以及 Ubuntu 22，其他版本尚未经过充分测试。本项目主要面向服务器场景，暂未针对桌面环境实现对应检查项。
+本项目基于 [OVH-debian-cis](https://github.com/ovh/debian-cis) 框架，并结合 Debian GNU/Linux 9 的一些特性进行了优化。同时参考了安全合规基线 STIG（[STIG Red_Hat_Enterprise_Linux_7_V2R5](redhat-STIG-DOCs/U_Red_Hat_Enterprise_Linux_7_V2R5_STIG.zip) 及 [STIG Ubuntu V1R2](https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_Canonical_Ubuntu_16-04_LTS_V1R2_STIG.zip)）和 CIS（[cisecurity.org](https://www.cisecurity.org/)），补充了安全检查项；另外也结合 HardenedLinux 社区在实际生产环境中的经验，实现了一些额外安全检查项的审计功能。项目不仅支持安全审计，也支持自动修复。
 
 审计功能的使用示例： 
 ```console
@@ -18,7 +18,7 @@ hardening                 [INFO] Treating /home/test/harbian-audit/bin/hardening
 [...]
 ################### SUMMARY ###################
       Total Available Checks : 271
-         Total Runned Checks : 271
+         Total Checks Run : 271
          Total Passed Checks : [ 226/271 ]
          Total Failed Checks : [  44/271 ]
    Enabled Checks Percentage : 100.00 %
@@ -33,7 +33,7 @@ $ git clone https://github.com/hardenedlinux/harbian-audit.git && cd harbian-aud
 # sed -i "s#CIS_ROOT_DIR=.*#CIS_ROOT_DIR='$(pwd)'#" /etc/default/cis-hardening
 # bin/hardening.sh --init
 ```
-### 对所有的安全检查项进行审计 
+### 对所有安全检查项执行审计 
 ```
 # bin/hardening.sh --audit-all
 hardening                 [INFO] Treating /home/test/harbian-audit/bin/hardening/1.1_install_updates.sh
@@ -47,13 +47,13 @@ hardening                 [INFO] Treating /home/test/harbian-audit/bin/hardening
 [...]
 ################### SUMMARY ###################
       Total Available Checks : 270
-         Total Runned Checks : 270
+         Total Checks Run : 270
          Total Passed Checks : [ 226/270 ]
          Total Failed Checks : [  44/270 ]
    Enabled Checks Percentage : 100.00 %
        Conformity Percentage : 83.70 %
 ```
-### 设置加固级别并进行自动修复  
+### 设置加固级别并执行自动修复  
 ```
 # bin/hardening.sh --set-hardening-level 5  
 # bin/hardening.sh --apply  
@@ -73,17 +73,17 @@ hardening                 [INFO] Treating /home/test/harbian-audit/bin/hardening
 ## 用法简介 
 
 ### 需要预装的软件  
-如果是使用的最小安装方式安装的Debian GNU/Linux系统，在使用此项目之前，需要安装如下的软件：
+如果 Debian GNU/Linux 系统采用最小化安装方式，在使用本项目之前需要先安装以下软件：
 ```
 # apt-get install -y bc net-tools pciutils 
 ```
-如果系统是Redhat/CentOS，在使用此项目前，需要安装如下的软件包：
+如果系统是 RedHat/CentOS，在使用本项目前，需要安装以下软件包：
 ```
 # yum install -y bc net-tools pciutils NetworkManager epel-release 
 ```
 
 ### 需要预先进行的配置 
-在使用此项目前，必须给所有要用到的用户设置了密码。如果没有设置密码的话，将在进行自动化加固后不能够登录到系统。例如(用户：root和test）:
+在使用本项目前，必须为所有会用到的用户设置密码。否则在执行自动化加固后，相关用户可能无法登录系统。例如（用户：root 和 test）：
 ```
  
 # passwd 
@@ -91,7 +91,7 @@ hardening                 [INFO] Treating /home/test/harbian-audit/bin/hardening
 ```
 
 ### 项目本身的配置 
-审计及修复的脚本代码位于bin/hardening目录中，每个脚本文件对应位于/etc/conf.d/[script_name].cfg的一个配置文件。每个脚本都能够单独设置为enabled或disabled，例如：
+审计与修复脚本位于 `bin/hardening` 目录中，每个脚本文件都对应一个位于 `/etc/conf.d/[script_name].cfg` 的配置文件。每个脚本都可以单独设置为 `enabled` 或 `disabled`，例如：
 ``disable_system_accounts``:
 
 ```
@@ -101,55 +101,56 @@ status=disabled
 EXCEPTIONS=""
 ```
 
-``status``参数可能的3个值： 
-- ``disabled`` (do nothing): 此脚本在执行时不会被运行 
-- ``audit`` (RO): 此脚本只会进行审计的检测 
-- ``enabled`` (RW): 此脚本不仅进行审计的检测，也能进行自动修改。
+`status` 参数有 3 个可选值： 
+- `disabled` (do nothing): 执行时不运行该脚本 
+- `audit` (RO): 仅执行审计检查 
+- `enabled` (RW): 执行审计检查，并尝试自动修复
 
-要生成每个脚本对应的配置文件并设置审计的级别，使用如下命令： 
-1) 当第一次执行本项目时，通过参数audit-all来生成etc/conf.d/[script_name].cfg 
+如需为每个脚本生成对应配置文件，并设置审计级别，可使用以下命令： 
+1. 首次执行本项目时，可通过 `audit-all` 参数生成 `etc/conf.d/[script_name].cfg`：
 ```
 # bash bin/hardening.sh --audit-all
 ```
-2) 使用参数set-hardening-level来设置对应级别的脚本的[script_name].cfg配置文件为enabled状态  
+2. 使用 `set-hardening-level` 参数，将对应级别的 `[script_name].cfg` 配置文件设为 `enabled` 状态：  
 ```
 # bash bin/hardening.sh --set-hardening-level <level>
 ```
-通用配置文件为``etc/hardening.cfg``，这个文件可以对日志文件的级别、备份目录进行控制，备份目录是当自动修复时对原配置文件进行备份的目录。
+通用配置文件为 `etc/hardening.cfg`。该文件可用于控制日志级别和备份目录；备份目录用于在自动修复时保存原始配置文件。
 
-### 审计及修复的操作 (进行加固后，必须进行“修复后”章节中的操作)
-要进行审计及修复，运行``bin/hardening.sh``，此命令有两个主要的执行模式：
-- ``--audit``: 对所有配置为enabled对应的脚本进行审计；
-- ``--apply``: 对所有配置为enabled对应的脚本进行审计及修复；
-另外, ``--audit-all`` 参数能够强制执行所有审计脚本，包括配置为disabled的脚本，此操作不会对系统有任何的影响(不会修复)；
-``--audit-all-enable-passed``参数可以用作快速启动配置的快捷方式，将在审计模式执行所有的脚本。如果脚本对应的审计通过，此脚本对应的配置文件将自动配置为enabled。如果你已经自定义了你的配置文件，别使用此参数进行执行。
+### 审计及修复操作（执行加固后，必须完成“修复后必须进行的操作”章节中的内容）
+执行审计或修复时，运行 `bin/hardening.sh`。该命令主要有两种执行模式：
+- `--audit`: 对所有配置为 `enabled` 的脚本执行审计
+- `--apply`: 对所有配置为 `enabled` 的脚本执行审计并尝试修复
 
-使用如下命令进行加固/修复系统:
+另外，`--audit-all` 参数会强制执行所有审计脚本，包括配置为 `disabled` 的脚本；该操作不会修改系统（即不会执行修复）。
+`--audit-all-enable-passed` 参数可用作快速初始化配置的快捷方式：它会以审计模式执行所有脚本，如果某个脚本审计通过，则自动将其对应配置文件设为 `enabled`。如果你已经自定义了配置文件，不建议使用此参数。
+
+使用以下命令对系统进行加固/修复：
 ```
 # bash bin/hardening.sh --apply 
 ```
 
-## 修复后必须进行的操作 (非常重要)
-当set-hardening-level配置为5（最高等级）且使用--apply运行了后，需要进行如下的操作：
-1) 当9.4项被修复后(Restrict Access to the su Command), 如果必须使用su的场景，例如如果使用ssh远程登录，当以普通用户登录后需要使用su命令时，可以使用如下命令进行解除限制：
+## 修复后必须进行的操作（非常重要）
+当 `set-hardening-level` 设为 5（最高等级）并执行 `--apply` 后，还需要完成以下操作：
+1. 当 9.4 项（Restrict Access to the su Command）被修复后，如果仍然存在必须使用 `su` 的场景，例如通过 SSH 以普通用户登录后再切换到其他用户，可以使用以下命令临时解除限制：
 ```
 # sed -i '/^[^#].*pam_wheel.so.*/s/^/# &/' /etc/pam.d/su 
 ```
-暂时注释掉包含pam_wheel.so的行，当使用完su命令后，请去掉此行的注释。
+该命令会临时注释掉包含 `pam_wheel.so` 的行。使用完 `su` 后，请恢复该行的注释状态。
 
-2) 当7.4.4项被修复后（7.4.4_hosts_deny.sh）, 系统将拒绝所有的连接（例如ssh连接），所以需要设置/etc/hosts.allow文件中允许访问此主机的列表，例如：
+2. 当 7.4.4 项（`7.4.4_hosts_deny.sh`）被修复后，系统将拒绝所有连接（例如 SSH 连接），因此需要在 `/etc/hosts.allow` 中配置允许访问此主机的来源，例如：
 ```
 # echo "ALL: 192.168.1. 192.168.5." >> /etc/hosts.allow
 ```
-此示例配置表示仅允许192.168.1.[1-255] 192.168.5.[1-255]两个网段能够访问此系统。 具体配置请根据实际场景进行配置。 
+该示例表示仅允许 `192.168.1.[1-255]` 和 `192.168.5.[1-255]` 两个网段访问此系统。请根据实际场景调整配置。 
 
-3) 为普通用户设置能力，例如(用户名为test):
+3. 为普通用户授予 sudo 权限，例如（用户名为 `test`）：
 ```
 # sed -i "/^root/a\test    ALL=(ALL:ALL) ALL" /etc/sudoers 
 ```
 
-4) 设置基本的iptables防火墙规则 
-根据实现场景进行防火墙规则的配置，可参考HardenedLinux社区归纳的基于Debian GNU/Linux的防火墙规则的基本规则：
+4. 设置基础 iptables 防火墙规则  
+请根据实际场景配置防火墙规则，可参考 HardenedLinux 社区整理的 Debian GNU/Linux 基础防火墙规则：
 [etc.iptables.rules.v4.sh](https://github.com/hardenedlinux/harbian-audit/blob/master/docs/configurations/etc.iptables.rules.v4.sh)
 
 基于iptables的部署:
@@ -160,35 +161,35 @@ $ INTERFACENAME="your network interfacename(Example eth0)"
 # iptables-save > /etc/iptables/rules.v4 
 # ip6tables-save > /etc/iptables/rules.v6 
 ```
-基于nft的部署：
-按照以下命令修改nftables.conf(你的对外网口的名称，例如：eth0):
+基于 nft 的部署：
+按以下命令修改 `nftables.conf`（将对外网卡名称替换为实际值，例如 `eth0`）：
 ```
 $ sed -i 's/^define int_if = ens33/define int_if = eth0/g' etc.nftables.conf 
 # nft -f ./etc.nftables.conf 
 ```
-5) 当所有安全基线项都修复完成后，使用--final方法将完成以下的最终的工作：
-   1.使用passwd命令去重新设置常规用户及root用户的密码，以满足pam_cracklib模块配置的密码强度和健壮性。
-   2. 重新初始化aide工具的数据库。
+5. 当所有安全基线项都修复完成后，可使用 `--final` 完成以下收尾工作：
+   1. 使用 `passwd` 命令重新设置普通用户及 root 用户的密码，以满足 `pam_cracklib` 模块对密码强度的要求。
+   2. 重新初始化 aide 工具的数据库。
 ```
 # bin/hardening.sh --final
 ```
 
 ## 特别注意 
 
-### 必须在第一次修复应用后进行修复的项  
-8.1.35  因为此项一旦设置，审计规则将不能够再进行添加。
+### 必须在第一次应用修复后处理的项  
+8.1.35：此项一旦设置完成，将无法继续添加新的审计规则。
 
-### 必须在所有项都修复应用后进行修复的项  
-8.4.1  8.4.2 这都是与aide检测文件完整性相关的项，最好是在所有项都修复好后再进行修复，以修复好的系统中的文件进行完整性的数据库的初始化。
+### 必须在所有项都修复完成后再处理的项  
+8.4.1、8.4.2：这两项都与 aide 文件完整性检测有关，最好在所有修复完成后再执行，以便基于修复完成后的系统文件初始化完整性数据库。
 
-### 一些检查项需要依赖多次修复，且操作系统需要多次重启 
-#### 需要进行两次修复的项  
+### 一些检查项需要多次修复，且操作系统可能需要多次重启 
+#### 需要执行两次修复的项  
 8.1.1.2  
 8.1.1.3  
 8.1.12  
 4.5  
 
-## 玩（如何添加检查项）
+## 扩展（如何添加检查项）
 
 **获取源码**
 
@@ -203,7 +204,7 @@ $ cp src/skel bin/hardening/99.99_custom_script.sh
 $ chmod +x bin/hardening/99.99_custom_script.sh
 $ cp src/skel.cfg etc/conf.d/99.99_custom_script.cfg
 ```
-将对应的配置文件配置为enabled，并进行审计及加固的测试：
+将对应配置文件设为 `enabled`，然后执行审计及加固测试：
 ```console
 $ sed -i "s/status=.+/status=enabled/" etc/conf.d/99.99_custom_script.cfg
 $ bash bin/hardening.sh --audit --only 99.99
@@ -219,7 +220,7 @@ This document is a description of the additions to the sections not included in 
 [CIS Debian GNU/Linux 9 Benchmark v1.0.0](https://benchmarks.cisecurity.org/downloads/show-single/index.cfm?file=debian8.100)  
 [harbian audit Debian Linux 9 Benchmark](https://github.com/hardenedlinux/harbian-audit/blob/master/docs/harbian_audit_Debian_9_Benchmark_v0.1.mkd)  
 
-### 手动修复的操作文档列表  
+### 手动修复操作文档列表  
 [How to config grub2 password protection](https://github.com/hardenedlinux/harbian-audit/blob/master/docs/configurations/manual-operation-docs/how_to_config_grub2_password_protection.mkd)  
 [How to persistent iptables rules with debian 9](https://github.com/hardenedlinux/harbian-audit/blob/master/docs/configurations/manual-operation-docs/how_to_persistent_iptables_rules_with_debian_9.mkd)  
 [How to deploy audisp-remote for auditd log](https://github.com/hardenedlinux/harbian-audit/blob/master/docs/configurations/manual-operation-docs/how_to_deploy_audisp_remote_for_audit_log.mkd)
@@ -233,7 +234,7 @@ This document is a description of the additions to the sections not included in 
 [nginx-mutual-ssl-proxy-http](https://github.com/hardenedlinux/harbian-audit/blob/master/docs/use-cases/tls-transmission-usecase/nginx-mutual-ssl-proxy-http-service/Readme.mkd)  
 [nginx-mutual-ssl-proxy-tcp-udp](https://github.com/hardenedlinux/harbian-audit/blob/master/docs/use-cases/tls-transmission-usecase/using-Nginx-as-SSL-tunnel-4TCP-UDP-service/Readme.mkd)   
 
-## harbian-audit合规制定的镜像  
+## harbian-audit 合规镜像  
 
 ### AMI(Amazon Machine Image) Public
 
@@ -281,6 +282,4 @@ Additionally, quoting the License:
 - **Center for Internet Security**: https://www.cisecurity.org/
 - **STIG V1R4**: https://iasecontent.disa.mil/stigs/zip/U_Red_Hat_Enterprise_Linux_7_V1R4_STIG.zip 
 - **Firewall Rules**: https://github.com/citypw/arsenal-4-sec-testing/blob/master/bt5_firewall/debian_fw
-
-
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ hardening                 [INFO] Treating /home/test/harbian-audit/bin/hardening
 [...]
 ################### SUMMARY ###################
       Total Available Checks : 271
-         Total Runned Checks : 271
+         Total Checks Run : 271
          Total Passed Checks : [ 226/271 ]
          Total Failed Checks : [  44/271 ]
    Enabled Checks Percentage : 100.00 %
@@ -48,7 +48,7 @@ hardening                 [INFO] Treating /home/test/harbian-audit/bin/hardening
 [...]
 ################### SUMMARY ###################
       Total Available Checks : 284
-         Total Runned Checks : 284
+         Total Checks Run : 284
          Total Passed Checks : [ 260/284 ]
          Total Failed Checks : [  24/284 ]
    Enabled Checks Percentage : 100.00 %

--- a/bin/hardening.sh
+++ b/bin/hardening.sh
@@ -395,17 +395,16 @@ TOTAL_TREATED_CHECKS=$((TOTAL_CHECKS-DISABLED_CHECKS))
 HARSUMMARY="/dev/shm/harbian-audit.summary"
 printf "%40s\n" "################### SUMMARY ###################" > ${HARSUMMARY}
 printf "%30s %s\n"        "Total Available Checks :" "$TOTAL_CHECKS" >> ${HARSUMMARY}
-printf "%30s %s\n"        "Total Runned Checks :" "$TOTAL_TREATED_CHECKS" >> ${HARSUMMARY}
+printf "%30s %s\n"        "Total Checks Run :" "$TOTAL_TREATED_CHECKS" >> ${HARSUMMARY}
 printf "%30s [ %7s ]\n"   "Total Passed Checks :" "$PASSED_CHECKS/$TOTAL_TREATED_CHECKS" >> ${HARSUMMARY}
 printf "%30s [ %7s ]\n"   "Total Failed Checks :" "$FAILED_CHECKS/$TOTAL_TREATED_CHECKS"  >> ${HARSUMMARY}
 printf "%30s %.2f %%\n"   "Enabled Checks Percentage :" "$( echo "($TOTAL_TREATED_CHECKS/$TOTAL_CHECKS) * 100" | bc -l)" >> ${HARSUMMARY}
 if [ $TOTAL_TREATED_CHECKS != 0 ]; then
     printf "%30s %.2f %%\n"   "Conformity Percentage :" "$( echo "($PASSED_CHECKS/$TOTAL_TREATED_CHECKS) * 100" | bc -l)" >> ${HARSUMMARY}
 else
-    printf "%30s %s %%\n"   "Conformity Percentage :" "N.A"  >> ${HARSUMMARY} # No check runned, avoid division by 0 
+    printf "%30s %s %%\n"   "Conformity Percentage :" "N.A"  >> ${HARSUMMARY} # No checks were run, avoid division by 0 
 fi
 
 cat ${HARSUMMARY}
 cat ${HARSUMMARY} | /usr/bin/logger -t "[CIS_Hardening] $SCRIPT_NAME" -p "user.info"
 rm -f ${HARSUMMARY}
-

--- a/bin/hardening/10.1.1_set_password_exp_days.sh
+++ b/bin/hardening/10.1.1_set_password_exp_days.sh
@@ -31,9 +31,9 @@ audit () {
 	fi
 
 	if [ $(egrep ^[^:]+:[^\!*] $SHA_FILE | awk -F: '$5 > "'$SSH_VALUE'" {print $1}' | wc -l) -gt 0 ]; then
-		crit "Have least user's maxinum password lifttime is greater than $SSH_VALUE day"
+		crit "Have least user's maximum password lifetime is greater than $SSH_VALUE day"
 	else
-		ok "All user's maxinum password lifttime is equal or less than $SSH_VALUE day"
+		ok "All user's maximum password lifetime is equal or less than $SSH_VALUE day"
 	fi
 }
 
@@ -56,7 +56,7 @@ apply () {
 		fi
 	fi
 	if [ $(egrep ^[^:]+:[^\!*] $SHA_FILE | awk -F: '$5 > "'$SSH_VALUE'" {print $1}' | wc -l) -gt 0 ]; then
-		warn "Have least user's maxinum password lifttime is greater than $SSH_VALUE day, Fixing"
+		warn "Have least user's maximum password lifetime is greater than $SSH_VALUE day, Fixing"
 		for USERNAME in $(egrep ^[^:]+:[^\!*] $SHA_FILE | awk -F: '$5 > "'$SSH_VALUE'" {print $1}'); 
 		do 
 			chage --maxdays $SSH_VALUE $USERNAME

--- a/bin/hardening/10.1.2_set_password_min_days_change.sh
+++ b/bin/hardening/10.1.2_set_password_min_days_change.sh
@@ -31,9 +31,9 @@ audit () {
 	fi
 		
 	if [ $(egrep ^[^:]+:[^\!*] $SHA_FILE | awk -F: '$4 < "'$SSH_VALUE'" {print $1}' | wc -l) -gt 0 ]; then
-		crit "Have least user's mininum password lifttime is not equal or less than $SSH_VALUE day"
+		crit "Have least user's minimum password lifetime is not equal or less than $SSH_VALUE day"
 	else
-		ok "All user's mininum password lifttime is $SSH_VALUE day"
+		ok "All user's minimum password lifetime is $SSH_VALUE day"
 	fi
 }
 
@@ -56,13 +56,13 @@ apply () {
 		fi
 	fi
 	if [ $(egrep ^[^:]+:[^\!*] $SHA_FILE | awk -F: '$4 < "'$SSH_VALUE'" {print $1}' | wc -l) -gt 0 ]; then
-		warn "Have least user's mininum password lifttime is not equal or less than $SSH_VALUE day, Fixing"
+		warn "Have least user's minimum password lifetime is not equal or less than $SSH_VALUE day, Fixing"
 		for USERNAME in $(egrep ^[^:]+:[^\!*] $SHA_FILE | awk -F: '$4 < "'$SSH_VALUE'" {print $1}');	
 		do
 			chage --mindays $SSH_VALUE $USERNAME
 		done
 	else
-		ok "All user's mininum password lifttime is $SSH_VALUE day"
+		ok "All user's minimum password lifetime is $SSH_VALUE day"
 	fi
 }
 

--- a/bin/hardening/10.1.3_set_password_exp_warning_days.sh
+++ b/bin/hardening/10.1.3_set_password_exp_warning_days.sh
@@ -30,9 +30,9 @@ audit () {
 			crit "$PATTERN is not present in $FILE"
 		fi
 		if [ $(egrep ^[^:]+:[^\!*] $SHA_FILE | awk -F: '$6 < "'$SSH_VALUE'" {print $1}' | wc -l) -gt 0 ]; then
-			crit "Have least user's maxinum password lifttime is greater than $SSH_VALUE day"
+			crit "Have least user's maximum password lifetime is greater than $SSH_VALUE day"
 		else
-			ok "All user's maxinum password lifttime is equal or less than $SSH_VALUE day"
+			ok "All user's maximum password lifetime is equal or less than $SSH_VALUE day"
 		fi
 }
 
@@ -55,7 +55,7 @@ apply () {
 		fi
 	fi
 	if [ $(egrep ^[^:]+:[^\!*] $SHA_FILE | awk -F: '$6 < "'$SSH_VALUE'" {print $1}' | wc -l) -gt 0 ]; then
-		warn "Have least user's maxinum password lifttime is greater than $SSH_VALUE day, Fixing"
+		warn "Have least user's maximum password lifetime is greater than $SSH_VALUE day, Fixing"
 		for USERNAME in $(egrep ^[^:]+:[^\!*] $SHA_FILE | awk -F: '$6 < "'$SSH_VALUE'" {print $1}'); 
 		do 
 			chage --warndays $SSH_VALUE $USERNAME

--- a/bin/hardening/10.1.5_set_password_lock_inactive_user.sh
+++ b/bin/hardening/10.1.5_set_password_lock_inactive_user.sh
@@ -36,12 +36,12 @@ audit_debian () {
 		fi
 
 		if [ $(egrep ^[^:]+:[^\!*] $SHA_FILE | awk -F: '{print $7}' | wc -w) -eq 0 ]; then
-			crit "Have least user's INACTIVE password lifttime is not set"
+			crit "Have least user's INACTIVE password lifetime is not set"
 		else
 			if [ $(egrep ^[^:]+:[^\!*] $SHA_FILE | awk -F: '$7 > "'$SSH_VALUE'" {print $1}' | wc -l) -gt 0 ]; then
-				crit "Have least user's INACTIVE password lifttime is greater than $SSH_VALUE day"
+				crit "Have least user's INACTIVE password lifetime is greater than $SSH_VALUE day"
 			else
-				ok "All user's INACTIVE password lifttime is equal or less than $SSH_VALUE day"
+				ok "All user's INACTIVE password lifetime is equal or less than $SSH_VALUE day"
 			fi
 		fi
 }
@@ -86,20 +86,20 @@ apply_debian () {
 		fi
 	fi
 	if [ $(egrep ^[^:]+:[^\!*] $SHA_FILE | awk -F: '{print $7}' | wc -w) -eq 0 ]; then
-		warn "Have least user's INACTIVE password lifttime is not set. Fixing"
+		warn "Have least user's INACTIVE password lifetime is not set. Fixing"
 		for USERNAME in $(egrep ^[^:]+:[^\!*] $SHA_FILE | awk -F: '{print $1}'); 
 		do 
 			chage --inactive $SSH_VALUE $USERNAME			
 		done
 	else
 		if [ $(egrep ^[^:]+:[^\!*] $SHA_FILE | awk -F: '$7 > "'$SSH_VALUE'" {print $1}' | wc -l) -gt 0 ]; then
-			warn "Have least user's INACTIVE password lifttime is greater than $SSH_VALUE day. Fixing"
+			warn "Have least user's INACTIVE password lifetime is greater than $SSH_VALUE day. Fixing"
 			for USERNAME in $(egrep ^[^:]+:[^\!*] $SHA_FILE | awk -F: '$7 > "'$SSH_VALUE'" {print $1}'); 
 			do 
 				chage --inactive $SSH_VALUE $USERNAME
 			done
 		else
-			ok "All user's INACTIVE password lifttime is equal or less than $SSH_VALUE day"
+			ok "All user's INACTIVE password lifetime is equal or less than $SSH_VALUE day"
 		fi
 	fi
 }
@@ -122,7 +122,7 @@ apply_centos () {
 		fi
 	fi
 	if [ $(egrep ^[^:]+:[^\!*] $SHA_FILE | awk -F: '{print $7}' | wc -w) -eq 0 ]; then
-		warn "Have least user's INACTIVE password lifttime is not set. Fixing"
+		warn "Have least user's INACTIVE password lifetime is not set. Fixing"
 		for USERNAME in $(egrep ^[^:]+:[^\!*] $SHA_FILE | awk -F: '{print $1}'); 
 		do 
 			chage --inactive $SSH_VALUE $USERNAME			

--- a/bin/hardening/12.10_find_suid_files.sh
+++ b/bin/hardening/12.10_find_suid_files.sh
@@ -7,7 +7,7 @@
 #
 # 12.10 Find SUID System Executables (Not Scored)
 #
-# set -e # One error, it's over, for some user to audit desktop evn  
+# set -e # One error, it's over, for some user to audit desktop even  
 
 # One variable unset, it's over
 set -u

--- a/bin/hardening/12.11_find_sgid_files.sh
+++ b/bin/hardening/12.11_find_sgid_files.sh
@@ -8,7 +8,7 @@
 # 12.11 Find SGID System Executables (Not Scored)
 #
 
-#set -e # One error, it's over, for some user to audit desktop evn 
+#set -e # One error, it's over, for some user to audit desktop even 
 
 # One variable unset, it's over
 set -u

--- a/bin/hardening/13.5_find_0_uid_non_root_account.sh
+++ b/bin/hardening/13.5_find_0_uid_non_root_account.sh
@@ -35,7 +35,7 @@ audit () {
         crit "Some accounts have uid 0"
         crit $RESULT
     else
-        ok "No account with uid 0 appart from root and potential configured exceptions"
+        ok "No account with uid 0 apart from root and potential configured exceptions"
     fi
 }
 

--- a/bin/hardening/2.25_disable_automounting.sh
+++ b/bin/hardening/2.25_disable_automounting.sh
@@ -23,7 +23,7 @@ audit () {
     	info "Checking if $SERVICE_NAME is enabled"
     	is_service_active $SERVICE_NAME
     	if [ $FNRET = 0 ]; then
-        	crit "$SERVICE_NAME is actived"
+        	crit "$SERVICE_NAME is active"
     	else
         	ok "$SERVICE_NAME is inactived"
     	fi

--- a/bin/hardening/4.1_restrict_core_dumps.sh
+++ b/bin/hardening/4.1_restrict_core_dumps.sh
@@ -40,7 +40,7 @@ audit_debian () {
 audit_centos () {
 	is_service_active $SERVICE_NAME
 	if [ $FNRET -eq 0 ]; then
-		crit "$SERVICE_NAME is actived"
+		crit "$SERVICE_NAME is active"
 		FNRET=1
 	else
 		ok "$SERVICE_NAME is inactived"

--- a/bin/hardening/4.5_enable_apparmor.sh
+++ b/bin/hardening/4.5_enable_apparmor.sh
@@ -24,7 +24,7 @@ SELINUXSETSTRING="security=selinux"
 
 audit_debian () {
 	if [ $(grep -c "${SELINUXSETSTRING}" /proc/cmdline) -eq 1 ]; then
-		ok "SELinux was actived. So pass."
+        ok "SELinux was active. So pass."
 		return 0
 	fi
     for PACKAGE in ${PACKAGES}
@@ -82,7 +82,7 @@ audit () {
 
 apply_debian () {
 	if [ $(grep -c "${SELINUXSETSTRING}" /proc/cmdline) -eq 1 ]; then
-		ok "SELinux was actived. So pass."
+        ok "SELinux was active. So pass."
 		return 0
 	fi
     if [ $FNRET = 0 ]; then

--- a/bin/hardening/4.6_enable_selinux.sh
+++ b/bin/hardening/4.6_enable_selinux.sh
@@ -26,7 +26,7 @@ audit_debian () {
 	check_aa_status
 	set -e
 	if [ $FNRET = 0 ]; then
-		ok "AppArmor was actived. So pass."
+        ok "AppArmor was active. So pass."
 		return 0
 	fi
 	for PACKAGE in ${PACKAGES}
@@ -42,7 +42,7 @@ audit_debian () {
 		ok "$PACKAGE is installed"
 	fi
 	if [ $(grep -c "${SETSTRING}" $PROC_CMDLINE) -eq 1 ]; then
-		ok "SELinux is actived."
+        ok "SELinux is active."
 		does_valid_pattern_exist_in_file $SELINUXCONF_FILE $SELINUXENFORCE_MODE
 		if [ ${FNRET} -eq 0 -a $(getenforce | grep -c 'Enforcing') -eq 1 ]; then
 			ok "SELinux is in Enforcing mode."
@@ -105,7 +105,7 @@ apply_debian () {
 	check_aa_status
 	set -e
 	if [ $FNRET = 0 ]; then
-		ok "AppArmor was actived. So pass."
+        ok "AppArmor was active. So pass."
 		return 0
 	fi
 	case $FNRET in 

--- a/bin/hardening/4.7_enable_selinux_policy.sh
+++ b/bin/hardening/4.7_enable_selinux_policy.sh
@@ -22,7 +22,7 @@ audit_debian () {
 	check_aa_status
 	set -e
 	if [ $FNRET = 0 ]; then
-		ok "AppArmor was actived. So pass."
+		ok "AppArmor was active. So pass."
 		return 0
 	fi
 	does_valid_pattern_exist_in_file $SELINUXCONF_FILE $SELINUXTYPE_VALUE
@@ -60,7 +60,7 @@ apply_debian () {
 	check_aa_status
 	set -e
 	if [ $FNRET = 0 ]; then
-		ok "AppArmor was actived. So pass."
+		ok "AppArmor was active. So pass."
 		return 0
 	fi
     if [ $FNRET = 0 ]; then

--- a/bin/hardening/5.1.3_disable_rsh_client.sh
+++ b/bin/hardening/5.1.3_disable_rsh_client.sh
@@ -14,7 +14,7 @@ set -u # One variable unset, it's over
 
 HARDENING_LEVEL=2
 
-# Based on aptitude search '~Prsh-client', exluding ssh-client OFC
+# Based on aptitude search '~Prsh-client', excluding ssh-client OFC
 PACKAGES='rsh-client rsh-redone-client heimdal-clients'
 
 # This function will be called if the script status is on enabled / audit mode

--- a/bin/hardening/5.3_enable_openssh_server.sh
+++ b/bin/hardening/5.3_enable_openssh_server.sh
@@ -34,7 +34,7 @@ audit () {
 	fi
 	is_service_active $SERVICE_NAME
 	if [ $FNRET = 0 ]; then
-		ok "$SERVICE_NAME is actived"
+		ok "$SERVICE_NAME is active"
 	else
 		crit "$SERVICE_NAME is inactive"
 	fi
@@ -61,7 +61,7 @@ apply () {
 	fi
 	is_service_active $SERVICE_NAME
 	if [ $FNRET = 0 ]; then
-		ok "$SERVICE_NAME is actived"
+		ok "$SERVICE_NAME is active"
 	else
 		warn "$SERVICE_NAME is inactive, set enable this service"
 		systemctl enable $SERVICE_NAME

--- a/bin/hardening/6.17_ensure_virul_scan_server_is_enabled.sh
+++ b/bin/hardening/6.17_ensure_virul_scan_server_is_enabled.sh
@@ -21,7 +21,7 @@ audit () {
 	if [ $OS_RELEASE -ne 2 ]; then
     	if [ $(dpkg -l  | grep -c $VIRULSERVER) -ge 1 ]; then
         	if [ $(systemctl | grep  "${VIRULSERVER}.service" | grep -c "active running") -ne 1 ]; then
-            	crit "$VIRULSERVER is not runing"
+            	crit "$VIRULSERVER is not running"
             	FNRET=2
         	else
             	ok "$VIRULSERVER is enable"

--- a/bin/hardening/7.7.1_enable_firewall.sh
+++ b/bin/hardening/7.7.1_enable_firewall.sh
@@ -42,10 +42,10 @@ audit_debian () {
     	done
     	if [ $FNRET = 0 ]; then
 	    	if [ $(systemctl status ${SERVICENAME}  | grep -c "Active:.active") -ne 1 ]; then
-            	crit "${SERVICENAME} service is not actived"
+            	crit "${SERVICENAME} service is not active"
             	FNRET=2
         	else
-            	ok "${SERVICENAME} service is actived"
+            	ok "${SERVICENAME} service is active"
             	FNRET=0
         	fi
 		fi
@@ -61,10 +61,10 @@ audit_debian () {
         fi
     	if [ $FNRET = 0 ]; then
 	    	if [ $(systemctl status ${SERVICENAME_NFT}  | grep -c "Active:.active") -ne 1 ]; then
-            	crit "${SERVICENAME_NFT} service is not actived"
+            	crit "${SERVICENAME_NFT} service is not active"
             	FNRET=4
         	else
-            	ok "${SERVICENAME_NFT} service is actived"
+            	ok "${SERVICENAME_NFT} service is active"
             	FNRET=0
         	fi
 	fi
@@ -88,10 +88,10 @@ audit_centos () {
 		for SERVICENAME in $SERVICENAME_CENTOS
 		do
 	    	if [ $(systemctl status ${SERVICENAME}  | grep -c "Active:.active") -ne 1 ]; then
-            	crit "${SERVICENAME} service is not actived"
+            	crit "${SERVICENAME} service is not active"
             	FNRET=2
         	else
-            	ok "${SERVICENAME} service is actived"
+            	ok "${SERVICENAME} service is active"
             	FNRET=0
         	fi
 		done
@@ -120,7 +120,7 @@ apply_debian () {
 			warn "$PACKAGE_NFT is absent, installing it"
 			apt_install $PACKAGE_NFT
         elif [ $FNRET = 2 ]; then
-            warn "Enable ${SERVICENAME} service to actived"
+            warn "Enable ${SERVICENAME} service to activate"
 			is_service_enabled ${SERVICENAME}
 			if [ $FNRET = 1 ]; then
 				systemctl enable ${SERVICENAME}
@@ -128,7 +128,7 @@ apply_debian () {
 			fi
             systemctl start ${SERVICENAME}
         elif [ $FNRET = 4 ]; then
-            warn "Enable ${SERVICENAME_NFT} service to actived"
+            warn "Enable ${SERVICENAME_NFT} service to activate"
 			is_service_enabled ${SERVICENAME_NFT}
 			if [ $FNRET = 1 ]; then
 				systemctl enable ${SERVICENAME_NFT}
@@ -150,7 +150,7 @@ apply_centos () {
                 yum_install $PACKAGE
             done
         elif [ $FNRET = 2 ]; then
-            warn "Enable ${SERVICENAME_CENTOS} service to actived"
+            warn "Enable ${SERVICENAME_CENTOS} service to activate"
 			for SERVICENAME in ${SERVICENAME_CENTOS}
 			do 
 				is_service_enabled ${SERVICENAME}

--- a/bin/hardening/8.1.10_record_dac_edit.sh
+++ b/bin/hardening/8.1.10_record_dac_edit.sh
@@ -31,7 +31,7 @@ audit () {
 		debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
 			does_pattern_exist_in_file $FILE "$AUDIT_VALUE"
@@ -53,7 +53,7 @@ apply () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	does_pattern_exist_in_file $FILE "$AUDIT_VALUE"

--- a/bin/hardening/8.1.15_record_sudoers_edit.sh
+++ b/bin/hardening/8.1.15_record_sudoers_edit.sh
@@ -26,7 +26,7 @@ audit () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	does_pattern_exist_in_file $FILE "$AUDIT_VALUE"
@@ -48,7 +48,7 @@ apply () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	does_pattern_exist_in_file $FILE "$AUDIT_VALUE"

--- a/bin/hardening/8.1.16_record_sudo_usage.sh
+++ b/bin/hardening/8.1.16_record_sudo_usage.sh
@@ -24,7 +24,7 @@ audit () {
     IFS=$'\n'
 	check_audit_path $AUDIT_VALUE 
 	if [ $FNRET -eq 1 ];then
-		warn "path is not exsit! Please check file path is exist!"
+		warn "path does not exist! Please check that the file path exists!"
 	else
 		does_pattern_exist_in_file $FILE "$AUDIT_VALUE"
 		if [ $FNRET != 0 ]; then
@@ -47,7 +47,7 @@ apply () {
 		add_end_of_file $FILE $AUDIT_VALUE
 		check_auditd_is_immutable_mode
 	elif [ $FNRET -eq 1 ];then
-		warn "path is not exsit! Please check file path is exist!"
+		warn "path does not exist! Please check that the file path exists!"
 	else
 		ok "$AUDIT_VALUE is present in $FILE"
 	fi

--- a/bin/hardening/8.1.17_record_kernel_modules.sh
+++ b/bin/hardening/8.1.17_record_kernel_modules.sh
@@ -43,7 +43,7 @@ audit () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	does_pattern_exist_in_file $FILE "$AUDIT_VALUE"
@@ -65,7 +65,7 @@ apply () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	does_pattern_exist_in_file $FILE "$AUDIT_VALUE"

--- a/bin/hardening/8.1.19_record_sshkeysign_usage.sh
+++ b/bin/hardening/8.1.19_record_sshkeysign_usage.sh
@@ -5,7 +5,7 @@
 #
 
 #
-# 8.1.19  Recored ssh-keysign command usage (Scored)
+# 8.1.19  Recorded ssh-keysign command usage (Scored)
 # Author : Samson wen, Samson <sccxboy@gmail.com>
 #
 
@@ -26,7 +26,7 @@ audit () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"
@@ -49,7 +49,7 @@ apply () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"

--- a/bin/hardening/8.1.20_record_open_by_handle_at_syscall.sh
+++ b/bin/hardening/8.1.20_record_open_by_handle_at_syscall.sh
@@ -5,7 +5,7 @@
 #
 
 #
-# 8.1.20  Recored open_by_handle_at syscall  (Scored)
+# 8.1.20  Recorded open_by_handle_at syscall  (Scored)
 # Author : Samson wen, Samson <sccxboy@gmail.com>
 #
 

--- a/bin/hardening/8.1.21_record_Events_that_privileged_passwd_cmd_usage.sh
+++ b/bin/hardening/8.1.21_record_Events_that_privileged_passwd_cmd_usage.sh
@@ -5,7 +5,7 @@
 #
 
 #
-# 8.1.21  Recored Events that privileged-passwd command usage (Scored)
+# 8.1.21  Recorded Events that privileged-passwd command usage (Scored)
 # Author : Samson wen, Samson <sccxboy@gmail.com>
 #
 
@@ -26,7 +26,7 @@ audit () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"
@@ -49,7 +49,7 @@ apply () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"

--- a/bin/hardening/8.1.22_record_Events_that_privileged_priv_change_cmd_usage.sh
+++ b/bin/hardening/8.1.22_record_Events_that_privileged_priv_change_cmd_usage.sh
@@ -5,7 +5,7 @@
 #
 
 #
-# 8.1.22  Recored Events that privileged-priv-change command usage (Scored)
+# 8.1.22  Recorded Events that privileged-priv-change command usage (Scored)
 # Author : Samson wen, Samson <sccxboy@gmail.com>
 #
 
@@ -26,7 +26,7 @@ audit () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"
@@ -49,7 +49,7 @@ apply () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"

--- a/bin/hardening/8.1.23_record_Events_that_privileged_postfix_cmd_usage.sh
+++ b/bin/hardening/8.1.23_record_Events_that_privileged_postfix_cmd_usage.sh
@@ -5,7 +5,7 @@
 #
 
 #
-# 8.1.23  Recored Events that privileged-postfix command usage (Scored)
+# 8.1.23  Recorded Events that privileged-postfix command usage (Scored)
 # Author : Samson wen, Samson <sccxboy@gmail.com>
 #
 
@@ -26,7 +26,7 @@ audit () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"
@@ -49,7 +49,7 @@ apply () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"

--- a/bin/hardening/8.1.24_record_crontab_cmd_usage.sh
+++ b/bin/hardening/8.1.24_record_crontab_cmd_usage.sh
@@ -5,7 +5,7 @@
 #
 
 #
-# 8.1.24  Recored crontab command usage (Scored)
+# 8.1.24  Recorded crontab command usage (Scored)
 # Author : Samson wen, Samson <sccxboy@gmail.com>
 #
 
@@ -26,7 +26,7 @@ audit () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"
@@ -49,7 +49,7 @@ apply () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"

--- a/bin/hardening/8.1.25_record_pam_timestamp_check_cmd_usage.sh
+++ b/bin/hardening/8.1.25_record_pam_timestamp_check_cmd_usage.sh
@@ -5,7 +5,7 @@
 #
 
 #
-# 8.1.25  Recored pam_timestamp_check command usage (Scored)
+# 8.1.25  Recorded pam_timestamp_check command usage (Scored)
 # Author : Samson wen, Samson <sccxboy@gmail.com>
 #
 
@@ -26,7 +26,7 @@ audit () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"
@@ -49,7 +49,7 @@ apply () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"

--- a/bin/hardening/8.1.26_record_pam_tally_cmd_usage.sh
+++ b/bin/hardening/8.1.26_record_pam_tally_cmd_usage.sh
@@ -5,7 +5,7 @@
 #
 
 #
-# 8.1.26  Recored pam_tally/pam_tally2 command usage(Only for Debian) (Scored)
+# 8.1.26  Recorded pam_tally/pam_tally2 command usage(Only for Debian) (Scored)
 # Replaced pam_tally2 with faillock in debian 11
 # Author : Samson wen, Samson <sccxboy@gmail.com> Author add this 
 #
@@ -29,7 +29,7 @@ audit () {
     	for AUDIT_VALUE in $AUDIT_PARAMS; do
 			check_audit_path $AUDIT_VALUE 
 			if [ $FNRET -eq 1 ];then
-				warn "path is not exsit! Please check file path is exist!"
+				warn "path does not exist! Please check that the file path exists!"
 				continue
 			else
         		debug "$AUDIT_VALUE should be in file $FILE"
@@ -57,7 +57,7 @@ apply () {
     	for AUDIT_VALUE in $AUDIT_PARAMS; do
 			check_audit_path $AUDIT_VALUE 
 			if [ $FNRET -eq 1 ];then
-				warn "path is not exsit! Please check file path is exist!"
+				warn "path does not exist! Please check that the file path exists!"
 				continue
 			else
         		debug "$AUDIT_VALUE should be in file $FILE"

--- a/bin/hardening/8.1.27_record_Events_that_modify_conf_files.sh
+++ b/bin/hardening/8.1.27_record_Events_that_modify_conf_files.sh
@@ -26,7 +26,7 @@ audit () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist! Rule: $AUDIT_VALUE"
+			warn "path does not exist! Please check that the file path exists! Rule: $AUDIT_VALUE"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"
@@ -49,7 +49,7 @@ apply () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "Path is not exsit when apply a rule: $AUDIT_VALUE ! Please check file path is exist!"
+			warn "Path does not exist when applying a rule: $AUDIT_VALUE! Please check that the file path exists!"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"

--- a/bin/hardening/8.1.28_record_acl_cmd_usage.sh
+++ b/bin/hardening/8.1.28_record_acl_cmd_usage.sh
@@ -5,7 +5,7 @@
 #
 
 #
-# 8.1.28  Recored Events that privileged-acl command usage (Scored)
+# 8.1.28  Recorded Events that privileged-acl command usage (Scored)
 # Author : Samson wen, Samson <sccxboy@gmail.com>
 #
 # todo to ensure path in debian 
@@ -25,7 +25,7 @@ audit () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"
@@ -48,7 +48,7 @@ apply () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"

--- a/bin/hardening/8.1.29_record_usermod_cmd_usage.sh
+++ b/bin/hardening/8.1.29_record_usermod_cmd_usage.sh
@@ -5,7 +5,7 @@
 #
 
 #
-# 8.1.29  Recored Events that usermod command usage (Scored)
+# 8.1.29  Recorded Events that usermod command usage (Scored)
 # Author : Samson wen, Samson <sccxboy@gmail.com>
 #
 
@@ -26,7 +26,7 @@ audit () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"
@@ -49,7 +49,7 @@ apply () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"

--- a/bin/hardening/8.1.30_record_unix_update_cmd_usage.sh
+++ b/bin/hardening/8.1.30_record_unix_update_cmd_usage.sh
@@ -5,7 +5,7 @@
 #
 
 #
-# 8.1.30  Recored Events that unix_update command usage (Scored)
+# 8.1.30  Recorded Events that unix_update command usage (Scored)
 # Author : Samson wen, Samson <sccxboy@gmail.com>
 #
 
@@ -24,7 +24,7 @@ audit () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"
@@ -47,7 +47,7 @@ apply () {
     for AUDIT_VALUE in $AUDIT_PARAMS; do
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	debug "$AUDIT_VALUE should be in file $FILE"

--- a/bin/hardening/8.1.31_record_file_transfer_related.sh
+++ b/bin/hardening/8.1.31_record_file_transfer_related.sh
@@ -27,7 +27,7 @@ audit () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	IFS=$d_IFS
@@ -51,7 +51,7 @@ apply () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
 			RESULT=$(echo $AUDIT_VALUE | awk -F"-F" '{print $2}' | awk -F"=" '{print $2}')

--- a/bin/hardening/8.1.32_record_ufw_of_debian_like.sh
+++ b/bin/hardening/8.1.32_record_ufw_of_debian_like.sh
@@ -35,7 +35,7 @@ audit () {
         	debug "$AUDIT_VALUE should be in file $FILE"
 			check_audit_path $AUDIT_VALUE 
 			if [ $FNRET -eq 1 ];then
-				warn "path is not exsit! Please check file path is exist!"
+				warn "path does not exist! Please check that the file path exists!"
 				continue
 			else
         		IFS=$d_IFS
@@ -63,7 +63,7 @@ apply () {
         	debug "$AUDIT_VALUE should be in file $FILE"
 			check_audit_path $AUDIT_VALUE 
 			if [ $FNRET -eq 1 ];then
-				warn "path is not exsit! Please check file path is exist!"
+				warn "path does not exist! Please check that the file path exists!"
 				continue
 			else
 				RESULT=$(echo $AUDIT_VALUE | awk -F"-F" '{print $2}' | awk -F"=" '{print $2}')

--- a/bin/hardening/8.1.33_record_iptables_restore_exec.sh
+++ b/bin/hardening/8.1.33_record_iptables_restore_exec.sh
@@ -29,7 +29,7 @@ audit () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	IFS=$d_IFS
@@ -53,7 +53,7 @@ apply () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
 			RESULT=$(echo $AUDIT_VALUE | awk -F"-F" '{print $2}' | awk -F"=" '{print $2}')

--- a/bin/hardening/8.1.4_record_date_time_edit.sh
+++ b/bin/hardening/8.1.4_record_date_time_edit.sh
@@ -41,7 +41,7 @@ audit () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	does_pattern_exist_in_file $FILE ""$AUDIT_VALUE""
@@ -63,7 +63,7 @@ apply () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	does_pattern_exist_in_file $FILE ""$AUDIT_VALUE""

--- a/bin/hardening/8.1.5_record_user_group_edit.sh
+++ b/bin/hardening/8.1.5_record_user_group_edit.sh
@@ -29,7 +29,7 @@ audit () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	does_pattern_exist_in_file $FILE "$AUDIT_VALUE"
@@ -51,7 +51,7 @@ apply () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	does_pattern_exist_in_file $FILE "$AUDIT_VALUE"

--- a/bin/hardening/8.1.6_record_network_edit.sh
+++ b/bin/hardening/8.1.6_record_network_edit.sh
@@ -42,7 +42,7 @@ audit () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	does_pattern_exist_in_file $FILE "$AUDIT_VALUE"
@@ -64,7 +64,7 @@ apply () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	does_pattern_exist_in_file $FILE "$AUDIT_VALUE"

--- a/bin/hardening/8.1.7_record_mac_edit.sh
+++ b/bin/hardening/8.1.7_record_mac_edit.sh
@@ -48,7 +48,7 @@ audit () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	does_pattern_exist_in_file $FILE "$AUDIT_VALUE"
@@ -86,7 +86,7 @@ apply () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	does_pattern_exist_in_file $FILE "$AUDIT_VALUE"

--- a/bin/hardening/8.1.8_record_login_logout.sh
+++ b/bin/hardening/8.1.8_record_login_logout.sh
@@ -34,7 +34,7 @@ audit () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	does_pattern_exist_in_file $FILE "$AUDIT_VALUE"
@@ -59,7 +59,7 @@ apply () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	does_pattern_exist_in_file $FILE "$AUDIT_VALUE"

--- a/bin/hardening/8.1.9_record_session_init.sh
+++ b/bin/hardening/8.1.9_record_session_init.sh
@@ -33,7 +33,7 @@ audit () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	does_pattern_exist_in_file $FILE "$AUDIT_VALUE"
@@ -58,7 +58,7 @@ apply () {
         debug "$AUDIT_VALUE should be in file $FILE"
 		check_audit_path $AUDIT_VALUE 
 		if [ $FNRET -eq 1 ];then
-			warn "path is not exsit! Please check file path is exist!"
+			warn "path does not exist! Please check that the file path exists!"
 			continue
 		else
         	does_pattern_exist_in_file $FILE "$AUDIT_VALUE"

--- a/bin/hardening/8.4.1_install_aide.sh
+++ b/bin/hardening/8.4.1_install_aide.sh
@@ -41,7 +41,7 @@ apply () {
 		else
         	apt_install $PACKAGE
 	    	aideinit -y -f
-        	info "${PACKAGE} is now installed but not fully functionnal, please see readme to go further"
+        	info "${PACKAGE} is now installed but not fully functional, please see readme to go further"
 		fi
     fi
 }

--- a/bin/hardening/9.2.11_pam_deny_times_tally2.sh
+++ b/bin/hardening/9.2.11_pam_deny_times_tally2.sh
@@ -120,7 +120,7 @@ apply_secconffile() {
 		warn "$DENYOPTION is not conf, add to $SECCONFFILE"
 		add_end_of_file $SECCONFFILE "$DENYOPTION = $DENY_VAL"
 	elif [ $FNRET = 3 ]; then
-		warn "Config file $SECCONFFILE is not exist! Please check it by youself"
+		warn "Config file $SECCONFFILE is not exist! Please check it by yourself"
 	else
 		warn "This param $FNRET was not defined!!!"
 	fi

--- a/bin/hardening/9.2.12_pam_lockout_failed_tally2.sh
+++ b/bin/hardening/9.2.12_pam_lockout_failed_tally2.sh
@@ -118,7 +118,7 @@ apply_secconffile() {
 		warn "$UNLOCKOPTION is not conf, add to $SECCONFFILE"
 		add_end_of_file $SECCONFFILE "$UNLOCKOPTION = $UNLOCK_VAL"
 	elif [ $FNRET = 3 ]; then
-		warn "Config file $SECCONFFILE is not exist! Please check it by youself"
+		warn "Config file $SECCONFFILE is not exist! Please check it by yourself"
 	else
 		warn "This param $FNRET was not defined!!!"
 	fi

--- a/bin/hardening/9.2.13_pam_even_deny_root_tally2.sh
+++ b/bin/hardening/9.2.13_pam_even_deny_root_tally2.sh
@@ -107,7 +107,7 @@ apply_secconffile() {
 	if [ $FNRET = 0 ]; then
 		ok "Option $DENYROOT is conf in $SECCONFFILE"
 	elif [ $FNRET = 1 ]; then
-		warn "Config file $SECCONFFILE is not exist! Please check it by youself"
+		warn "Config file $SECCONFFILE is not exist! Please check it by yourself"
 	elif [ $FNRET = 2 ]; then
 		warn "Option $DENYROOT is not conf in $SECCONFFILE, add it "
 		add_end_of_file $SECCONFFILE "$DENYROOT"

--- a/bin/hardening/9.3.13_sshd_limit_access.sh
+++ b/bin/hardening/9.3.13_sshd_limit_access.sh
@@ -6,7 +6,7 @@
 
 #
 # 9.3.13 Ensure SSH access is limited (Scored)
-# Auther: Samson-W (sccxboy@gmail.com)
+# Author: Samson-W (sccxboy@gmail.com)
 #
 
 set -e # One error, it's over

--- a/bin/hardening/9.3.25_sshd_logingracetime.sh
+++ b/bin/hardening/9.3.25_sshd_logingracetime.sh
@@ -6,7 +6,7 @@
 
 #
 # 9.3.25 Ensure SSH LoginGraceTime is set to one minute or less (Scored)
-# Auther: Samson-W (sccxboy@gmail.com)
+# Author: Samson-W (sccxboy@gmail.com)
 #
 
 set -e # One error, it's over

--- a/docs/complianced_image/AMI/how_to_creating_and_making_an_AMI_public.mkd
+++ b/docs/complianced_image/AMI/how_to_creating_and_making_an_AMI_public.mkd
@@ -146,7 +146,7 @@ Reset password for all users and reinit aide database:
 admin@ip:/opt/harbian-audit-master# ./bin/hardening.sh --final 
 ```
 
-#### Clear bash hostory 
+#### Clear bash history 
 ```
 # echo > ~/.bash_history 
 # history -cw 

--- a/docs/complianced_image/AMI/how_to_use_harbian_audit_complianced_Debian_9.mkd
+++ b/docs/complianced_image/AMI/how_to_use_harbian_audit_complianced_Debian_9.mkd
@@ -33,7 +33,7 @@ admin@ip-:/opt/harbian-audit-master# ./bin/hardening.sh --audit-all
 
 ################### SUMMARY ###################
       Total Available Checks : 256
-         Total Runned Checks : 256
+         Total Checks Run : 256
          Total Passed Checks : [ 227/256 ]
          Total Failed Checks : [  29/256 ]
    Enabled Checks Percentage : 100.00 %
@@ -68,6 +68,5 @@ This item requires the user to fix it himself. When the AMI is created, a new in
 
 ## Reference   
 [https://docs.aws.amazon.com/zh_cn/AWSEC2/latest/UserGuide/concepts.html](https://docs.aws.amazon.com/zh_cn/AWSEC2/latest/UserGuide/concepts.html)    
-
 
 

--- a/docs/complianced_image/QEMU/how_to_creating_and_making_a_QEMU_img_for_centos8.mkd
+++ b/docs/complianced_image/QEMU/how_to_creating_and_making_a_QEMU_img_for_centos8.mkd
@@ -160,7 +160,7 @@ $ cd /opt/harbian-audit-master
 # aideinit -y -f  
 ``` 
 
-#### Clear bash hostory  
+#### Clear bash history  
 ```
 # echo > ~/.bash_history 
 # history -cw 

--- a/docs/complianced_image/QEMU/how_to_creating_and_making_a_QEMU_img_for_debian9.mkd
+++ b/docs/complianced_image/QEMU/how_to_creating_and_making_a_QEMU_img_for_debian9.mkd
@@ -160,7 +160,7 @@ $ cd /opt/harbian-audit-master
 # aideinit -y -f  
 ``` 
 
-#### Clear bash hostory  
+#### Clear bash history  
 ```
 # echo > ~/.bash_history 
 # history -cw 

--- a/docs/configurations/build-simple-cdd-cfg/usr_share_simple-cdd_profiles_default.preseed
+++ b/docs/configurations/build-simple-cdd-cfg/usr_share_simple-cdd_profiles_default.preseed
@@ -1,5 +1,5 @@
 # This file real path is: /usr/share/simple-cdd/profiles/default.preseed
-# these are the basic debconf pre-seeding items needed for a miminal
+# these are the basic debconf pre-seeding items needed for a minimal
 # interaction debian etch install using debian-installer
 
 # this example pre-seeding file was largely based on
@@ -60,8 +60,8 @@ console-data    console-data/keymap/policy      select  Don't touch keymap
 
 # To preseed the root password, you have to put it in the clear in this
 # file. That is not a very good idea, use caution!
-#passwd   passwd/root-password    password r00tme
-#passwd   passwd/root-password-again  password r00tme
+#passwd   passwd/root-password    password r00time
+#passwd   passwd/root-password-again  password r00time
 
 # If you want to skip creation of a normal user account.
 #passwd   passwd/make-user    boolean false
@@ -80,7 +80,7 @@ console-data    console-data/keymap/policy      select  Don't touch keymap
 d-i netcfg/choose_interface select auto
 
 # Note that any hostname and domain names assigned from dhcp take
-# precidence over values set here. However, setting the values still
+# precedence over values set here. However, setting the values still
 # prevents the questions from being shown even if values come from dhcp.
 d-i netcfg/get_hostname string unassigned
 d-i netcfg/get_domain string unassigned

--- a/docs/configurations/debian-config-4-build-deb/how-to-build-deb-package.md
+++ b/docs/configurations/debian-config-4-build-deb/how-to-build-deb-package.md
@@ -13,7 +13,7 @@ export DEBEMAIL DEBFULLNAME
 EOF
 $ . ~/.bashrc
 ```
-## Download realese  
+## Download release  
 ```
 $ wget https://github.com/hardenedlinux/harbian-audit/archive/V0.4.1.tar.gz
 $ tar zxvf V0.4.1.tar.gz 

--- a/docs/configurations/etc.iptables.rules.v4.sh
+++ b/docs/configurations/etc.iptables.rules.v4.sh
@@ -25,7 +25,7 @@ fi
 #unlimited 
 $IPT -A INPUT -i lo -j ACCEPT
 $IPT -A OUTPUT -o lo -j ACCEPT
-# DROP all incomming traffic
+# DROP all incoming traffic
 $IPT -P INPUT DROP
 $IPT -P OUTPUT DROP
 $IPT -P FORWARD DROP
@@ -81,7 +81,7 @@ do
     $IPT -I INPUT -p tcp --dport 22 -i ${PUB_IF} -m state --state NEW -m recent --set
     $IPT -I INPUT -p tcp --dport 22 -i ${PUB_IF} -m state --state NEW -m recent  --update --seconds 60 --hitcount 4 -j LOGDROP
  done
-    # Allow full outgoing connection but no incomming stuff
+    # Allow full outgoing connection but no incoming stuff
     $IPT -A INPUT -p icmp -m icmp --icmp-type 4 -j ACCEPT
     $IPT -A OUTPUT -p icmp -m icmp --icmp-type 8 -j ACCEPT
 

--- a/docs/configurations/etc.iptables.rules.v6.sh
+++ b/docs/configurations/etc.iptables.rules.v6.sh
@@ -23,7 +23,7 @@ fi
 #unlimited 
 $IPT -A INPUT -i lo -j ACCEPT
 $IPT -A OUTPUT -o lo -j ACCEPT
-# DROP all incomming traffic
+# DROP all incoming traffic
 $IPT -P INPUT DROP
 $IPT -P OUTPUT DROP
 $IPT -P FORWARD DROP
@@ -79,7 +79,7 @@ do
     $IPT -I INPUT -p tcp --dport 22 -i ${PUB_IF} -m state --state NEW -m recent --set
     $IPT -I INPUT -p tcp --dport 22 -i ${PUB_IF} -m state --state NEW -m recent  --update --seconds 60 --hitcount 4 -j LOGDROP
  done
-    # Allow full outgoing connection but no incomming stuff
+    # Allow full outgoing connection but no incoming stuff
     $IPT -A INPUT -p ipv6-icmp -m ipv6-icmp  --icmpv6-type 4 -j ACCEPT
     $IPT -A OUTPUT -p ipv6-icmp -m ipv6-icmp --icmpv6-type 8 -j ACCEPT
 

--- a/docs/configurations/etc.login.defs
+++ b/docs/configurations/etc.login.defs
@@ -181,7 +181,7 @@ GID_MAX			60000
 
 #
 # Max number of login retries if password is bad. This will most likely be
-# overriden by PAM, since the default pam_unix module has it's own built
+# overridden by PAM, since the default pam_unix module has it's own built
 # in of 3 retries. However, this is a safe fallback in case you are using
 # an authentication module that does not enforce PAM_MAXTRIES.
 #
@@ -226,7 +226,7 @@ USERGROUPS_ENAB yes
 #
 # Instead of the real user shell, the program specified by this parameter
 # will be launched, although its visible name (argv[0]) will be the shell's.
-# The program may do whatever it wants (logging, additional authentification,
+# The program may do whatever it wants (logging, additional authentication,
 # banner, ...) before running the actual shell.
 #
 # FAKE_SHELL /bin/fakeshell
@@ -297,7 +297,7 @@ ENCRYPT_METHOD SHA512
 #						#
 # These options are now handled by PAM. Please	#
 # edit the appropriate file in /etc/pam.d/ to	#
-# enable the equivelants of them.
+# enable the equivalents of them.
 #
 ###############
 

--- a/docs/harbian_audit_Debian_9_Benchmark_v0.1.mkd
+++ b/docs/harbian_audit_Debian_9_Benchmark_v0.1.mkd
@@ -13,7 +13,7 @@ The operating system must prevent the installation of software, patches, service
 ### Rationale
 Changes to any software components can have significant effects on the overall security of the operating system. This requirement ensures the software has not been tampered with and that it has been provided by a trusted vendor. Accordingly, patches, service packs, device drivers, or operating system components must be signed with a certificate recognized and approved by the organization. Verifying the authenticity of the software prior to installation validates the integrity of the patch or upgrade received from a vendor. This verifies the software has not been tampered with and that it has been provided by a trusted vendor. Self-signed certificates are disallowed by this requirement. The operating system should not have to verify the software again. This requirement does not mandate DoD certificates for this purpose; however, the certificate used to verify the software must be from an approved CA.
 
-### Aduit
+### Audit
 Verify the operating system prevents the installation of patches, service packs, device drivers, or operating system components from a repository without verification that they have been digitally signed using a certificate that is recognized and approved by the organization. Check that apt verifies the signature of packages from a repository prior to install with the following command:
 ```
 $ sudo grep AllowUnauthenticated /etc/apt/ -r 
@@ -35,7 +35,7 @@ The operating system must prevent the installation of software, patches, service
 ### Rationale
 Changes to any software components can have significant effects on the overall security of the operating system. This requirement ensures the software has not been tampered with and that it has been provided by a trusted vendor. Accordingly, patches, service packs, device drivers, or operating system components must be signed with a certificate recognized and approved by the organization. Verifying the authenticity of the software prior to installation validates the integrity of the patch or upgrade received from a vendor. This verifies the software has not been tampered with and that it has been provided by a trusted vendor. Self-signed certificates are disallowed by this requirement. The operating system should not have to verify the software again. This requirement does not mandate DoD certificates for this purpose; however, the certificate used to verify the software must be from an approved CA.
 
-### Aduit
+### Audit
 Verify the operating system prevents the installation of patches, service packs, device drivers, or operating system components from a repository without verification that they have been digitally signed using a certificate that is recognized and approved by the organization. Check that apt verifies the signature of packages from a repository prior to install with the following command:
 ```
 $ sudo grep -v "^#" /etc/dpkg/dpkg.cfg | grep no-debsig
@@ -57,7 +57,7 @@ The operating system must prevent the installation of software, patches, service
 ### Rationale
 Changes to any software components can have significant effects on the overall security of the operating system. This requirement ensures the software has not been tampered with and that it has been provided by a trusted vendor. Accordingly, patches, service packs, device drivers, or operating system components must be signed with a certificate recognized and approved by the organization. Verifying the authenticity of the software prior to installation validates the integrity of the patch or upgrade received from a vendor. This ensures the software has not been tampered with and that it has been provided by a trusted vendor. Self-signed certificates are disallowed by this requirement. The operating system should not have to verify the software again. This requirement does not mandate DoD certificates for this purpose; however, the certificate used to verify the software must be from an approved Certificate Authority.
 
-### Aduit
+### Audit
 
 Verify the operating system prevents the installation of patches, service packs, device drivers, or operating system components of local packages without verification of the repository metadata. Check that apt verifies the package metadata prior to install with the following command:
 ```
@@ -83,7 +83,7 @@ File systems that contain user home directories must be mounted to prevent files
 ### Rationale
 The "nosuid" mount option causes the system to not execute setuid and setgid files with owner privileges. This option must be used for mounting any file system not containing approved setuid and setguid files. Executing files from untrusted file systems increases the opportunity for unprivileged users to attain unauthorized administrative access.
 
-### Aduit
+### Audit
 Verify file systems that contain user home directories are mounted with the "nosuid" option. Find the file system(s) that contain the user home directories with the following command:
 Note: If a separate file system has not been created for the user home directories (user home directories are mounted under "/"), this is not a finding as the "nosuid" option cannot be used on the "/" system.
 ```
@@ -112,7 +112,7 @@ File systems that are being imported via Network File System (NFS) must be mount
 ### Rationale
 The "nosuid" mount option causes the system to not execute "setuid" and "setgid" files with owner privileges. This option must be used for mounting any file system not containing approved "setuid" and "setguid" files. Executing files from untrusted file systems increases the opportunity for unprivileged users to attain unauthorized administrative access.
 
-### Aduit
+### Audit
 Verify file systems that are being NFS exported are mounted with the "nosuid" option. Find the file system(s) that contain the directories being exported with the following command:
 ```
 $ sudo more /etc/fstab | grep nfs
@@ -135,7 +135,7 @@ File systems that are being imported via Network File System (NFS) must be mount
 ### Rationale
 The "noexec" mount option causes the system to not execute binary files. This option must be used for mounting any file system not containing approved binary files as they may be incompatible. Executing files from untrusted file systems increases the opportunity for unprivileged users to attain unauthorized administrative access.
 
-### Aduit
+### Audit
 Verify file systems that are being NFS exported are mounted with the "noexec" option. Find the file system(s) that contain the directories being exported with the following command:
 ```
 $ sudo more /etc/fstab | grep nfs
@@ -158,7 +158,7 @@ The Network File System (NFS) must be configured to use RPCSEC_GSS.
 ### Rationale
 When an NFS server is configured to use RPCSEC_SYS, a selected userid and groupid are used to handle requests from the remote user. The userid and groupid could mistakenly or maliciously be set incorrectly. The RPCSEC_GSS method of authentication uses certificates on the server and client systems to more securely authenticate the remote mount request.
 
-### Aduit
+### Audit
 Verify "AUTH_GSS" is being used to authenticate NFS mounts. To check if the system is importing an NFS file system, look for any entries in the "/etc/fstab" file that have a file system type of "nfs" with the following command:
 ```
 $ sudo cat /etc/fstab | grep nfs
@@ -180,7 +180,7 @@ USB Devices must be disabled.
 ### Rationale
 USB Devices permits easy introduction of unknown devices, thereby facilitating malicious activity.
 
-### Aduit
+### Audit
 If there is an HBSS with a Device Control Module and a Data Loss Prevention mechanism, this requirement is not applicable. Verify the operating system disables the ability to use USB devices. Check to see if USB Devices is disabled with the following command:
 ```
 $ sudo grep '^ACTION=="add", SUBSYSTEMS=="usb", TEST=="authorized_default", ATTR{authorized_default}="0"' /etc/udev/rules.d/ -r
@@ -219,7 +219,7 @@ A session time-out lock is a temporary action taken when a user stops work and m
 ### Rationale
 You can use the lock function of the screen to lock the current terminal and prevent the current session from exiting due to timeout. 
 
-### Aduit
+### Audit
 Verify the operating system has the screen package installed. Check to see if the screen package is installed with the following command:
 ```
 # dpkg -s screen | grep  '^Status: install'
@@ -243,7 +243,7 @@ All networked systems must have SSH installed.
 ### Rationale
 Without protection of the transmitted information, confidentiality and integrity may be compromised because unprotected communications can be intercepted and either read or altered. This requirement applies to both internal and external networks and all types of information system components from which information can be transmitted (e.g., servers, mobile devices, notebook computers, printers, copiers, scanners, and facsimile machines). Communication paths outside the physical protection of a controlled boundary are exposed to the possibility of interception and modification. Protecting the confidentiality and integrity of organizational information can be accomplished by physical means (e.g., employing physical distribution systems) or by logical means (e.g., employing cryptographic techniques). If physical means of protection are employed, logical means (cryptography) do not have to be employed, and vice versa.
 
-### Aduit
+### Audit
 Check to see if sshd is installed with the following command:
 ```
 # dpkg -s openssh-server | grep '^Status: install'
@@ -270,7 +270,7 @@ The x86 Ctrl-Alt-Delete key sequence must be disabled.
 ### Rationale
 A locally logged-on user who presses Ctrl-Alt-Delete, when at the console, can reboot the system. If accidentally pressed, as could happen in the case of a mixed OS environment, this can create the risk of short-term loss of availability of systems due to unintentional reboot. In the GNOME graphical environment, risk of unintentional reboot from the Ctrl-Alt-Delete sequence is reduced because the user will be prompted before any action is taken.
 
-### Aduit
+### Audit
 Verify the operating system is not configured to reboot the system when Ctrl-Alt-Delete is pressed. Check that the ctrl-alt-del.service is not active with the following command:
 ```
 # find /lib/systemd/ /etc/systemd/ -name ctrl-alt-del.target -exec ls -l {} \;| grep -v "/dev/null" | awk '{print $NF}'
@@ -303,7 +303,7 @@ Systems must have sudo installed.
 ### Rationale
 The su command allows a user to run a command or shell as another user. The program has been superseded by sudo, which allows for more granular control over privileged access. 
 
-### Aduit
+### Audit
 Verify the operating system has the sudo package installed. Check to see if the sudo package is installed with the following command:
 ```
 # dpkg -s sudo | grep  '^Status: install'
@@ -326,7 +326,7 @@ The system must use a virus scan program.
 ### Rationale
 Virus scanning software can be used to protect a system from penetration from computer viruses and to limit their spread through intermediate systems.  The virus scanning software should be configured to perform scans dynamically on accessed files. If this capability is not available, the system must be configured to scan, at a minimum, all altered files on the system on a daily basis.
 
-### Aduit
+### Audit
 Verify the system is using a virus scan program. check for the presence of "clamav" on the system with the following command:
 ```
 # systemctl | grep clamav-daemon
@@ -351,7 +351,7 @@ The system must update the virus scan program every seven days or more frequentl
 ### Rationale
 Virus scanning software can be used to protect a system from penetration from computer viruses and to limit their spread through intermediate systems.  The virus scanning software should be configured to check for software and virus definition updates with a frequency no longer than seven days. If a manual process is required to update the virus scan software or definitions, it must be documented with the Information System Security Officer (ISSO).
 
-### Aduit
+### Audit
 Verify the system is using a virus scan program and the virus definition file is less than seven days old. Check for the presence of "clamav" on the system with the following command:
 ```
 # systemctl | grep clamav
@@ -380,7 +380,7 @@ Network interfaces must not be in promiscuous mode.
 ### Rationale
 Network interfaces in promiscuous mode allow for the capture of all network traffic visible to the system. If unauthorized individuals can access these applications, it may allow then to collect information such as logon IDs, passwords, and key exchanges between systems. If the system is being used to perform a network troubleshooting function, the use of these tools must be documented with the Information System Security Officer (ISSO) and restricted to only authorized personnel.
 
-### Aduit
+### Audit
 Verify network interfaces are not in promiscuous mode unless approved by the ISSO and documented. Check for the status with the following command: 
 ```
 # ip link | grep -i promisc
@@ -404,7 +404,7 @@ The host must be configured to prohibit or restrict the use of functions, ports,
 ### Rationale
 In order to prevent unauthorized connection of devices, unauthorized transfer of information, or unauthorized tunneling (i.e., embedding of data types within data types), organizations must disable or restrict unused or unnecessary physical and logical ports/protocols on information systems. Operating systems are capable of providing a wide variety of functions and services. Some of the functions and services provided by default may not be necessary to support essential organizational operations. Additionally, it is sometimes convenient to provide multiple services from a single component (e.g., VPN and IPS); however, doing so increases risk over limiting the services provided by any one component. To support the requirements and principles of least functionality, the operating system must support the organizational requirements, providing only essential capabilities and limiting the use of ports, protocols, and/or services to only those required, authorized, and approved to conduct official business or to address authorized quality of life issues.
 
-### Aduit
+### Audit
 Inspect the firewall configuration and running services to verify that it is configured to prohibit or restrict the use of functions, ports, protocols, and/or services that are unnecessary or prohibited. Check which services are currently active with the following command:
 ```
 # /sbin/iptables -S | grep -Ec "^-A|^-I"
@@ -426,7 +426,7 @@ The operating system must protect against or limit the effects of Denial of Serv
 ### Rationale
 DoS is a condition when a resource is not available for legitimate users. When this occurs, the organization either cannot accomplish its mission or must operate at degraded capacity. This requirement addresses the configuration of the operating system to mitigate the impact of DoS attacks that have occurred or are ongoing on system availability. For each system, known and potential DoS attacks must be identified and solutions for each type implemented. A variety of technologies exist to limit or, in some cases, eliminate the effects of DoS attacks (e.g., limiting processes or establishing memory partitions). Employing increased capacity and bandwidth, combined with service redundancy, may reduce the susceptibility to some DoS attacks.
 
-### Aduit
+### Audit
 Verify the operating system protects against or limits the effects of DoS attacks by ensuring the operating system is implementing rate-limiting measures on impacted network interfaces. Check the firewall configuration with the following command:
 ```
 # /sbin/iptables -S | grep -E "\-m.*limit" | grep -Ec "\-\-limit-burst"
@@ -447,7 +447,7 @@ The operating system must shut down upon audit processing failure, unless availa
 ### Rationale
 It is critical for the appropriate personnel to be aware if a system is at risk of failing to process audit logs as required. Without this notification, the security personnel may be unaware of an impending failure of the audit capability, and system operation may be adversely affected. Audit processing failures include software/hardware errors, failures in the audit capturing mechanisms, and audit storage capacity being reached or exceeded. This requirement applies to each audit data storage repository (i.e., distinct information system component where audit records are stored), the centralized audit storage capacity of organizations (i.e., all audit data storage repositories combined), or both.
 
-### Aduit
+### Audit
 Confirm the audit configuration regarding how auditing processing failures are handled. Check to see what level "auditctl" is set to with following command: 
 ```
 # auditctl -s | grep -i "fail"
@@ -485,7 +485,7 @@ The operating system must off-load audit records onto a different system or medi
 ### Rationale
 Information stored in one location is vulnerable to accidental or incidental deletion or alteration. Off-loading is a common process in information systems with limited audit storage capacity.
 
-### Aduit
+### Audit
 Verify the operating system off-loads audit records onto a different system or media from the system being audited. To determine the remote server that the records are being sent to, use the following command:
 ```
 # grep -i remote_server /etc/audisp/audisp-remote.conf
@@ -507,7 +507,7 @@ The operating system must encrypt the transfer of audit records off-loaded onto 
 ### Rationale
 Information stored in one location is vulnerable to accidental or incidental deletion or alteration.\n\nOff-loading is a common process in information systems with limited audit storage capacity.
 
-### Aduit
+### Audit
 Verify the operating system encrypts audit records off-loaded onto a different system or media from the system being audited. To determine if the transfer is encrypted, use the following command:
 ```
 # grep -i enable_krb5 /etc/audisp/audisp-remote.conf
@@ -532,7 +532,7 @@ The audit system must take appropriate action when the audit storage volume is f
 ### Rationale
 Taking appropriate action in case of a filled audit storage volume will minimize the possibility of losing audit records.
 
-### Aduit
+### Audit
 Verify the action the operating system takes if the disk the audit records are written to becomes full. To determine the action that takes place if the disk is full on the remote server, use the following command:
 ```
 # grep -i disk_full_action /etc/audisp/audisp-remote.conf
@@ -557,7 +557,7 @@ The audit system must take appropriate action when the network connection fails.
 ### Rationale
 Taking appropriate action in case of network connection is failure.
 
-### Aduit
+### Audit
 Verify the action the operating system takes if the network connection fails. To determine the action that takes place if the network connection failure on the remote server, use the following command:
 ```
 # grep -i network_failure_action /etc/audisp/audisp-remote.conf
@@ -582,7 +582,7 @@ The operating system must immediately notify the System Administrator (SA) and I
 ### Rationale
 If security personnel are not notified immediately when storage volume reaches 75 percent utilization, they are unable to plan for audit record storage capacity expansion.
 
-### Aduit
+### Audit
 Verify the operating system immediately notifies the SA and ISSO (at a minimum) when allocated audit record storage volume reaches 75 percent of the repository maximum audit record storage capacity. Check the system configuration to determine the partition the audit records are being written to with the following command:
 ```
 # grep log_file /etc/audit/auditd.conf
@@ -614,7 +614,7 @@ Filesystem     1M-blocks  Used Available Use% Mounted on
 ```
 Set the value of the "space_left" keyword in "/etc/audit/auditd.conf" to 25 percent of the partition size.
 
-## 8.1.19 Recored ssh-keysign command usage (scored) 
+## 8.1.19 Recorded ssh-keysign command usage (scored) 
 
 ### Profile Applicability
 Level 4
@@ -625,7 +625,7 @@ All uses of the ssh-keysign command must be audited.
 ### Rationale
 Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information. At a minimum, the organization must audit the full-text recording of privileged ssh commands. The organization must maintain audit trails in sufficient detail to reconstruct events to determine the cause and impact of compromise.
 
-### Aduit
+### Audit
 Verify the operating system generates audit records when successful/unsuccessful attempts to use the "ssh-keysign" command occur. Check for the following system call being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules": 
 ```
 # grep -i /usr/lib/openssh/ssh-keysign /etc/audit/audit.rules
@@ -640,7 +640,7 @@ Configure the operating system to generate audit records when successful/unsucce
 ```
 The audit daemon must be restarted for the changes to take effect.
 
-## 8.1.20 Recored open_by_handle_at syscall (scored) 
+## 8.1.20 Recorded open_by_handle_at syscall (scored) 
 
 ### Profile Applicability
 Level 4
@@ -651,7 +651,7 @@ All uses of the open_by_handle_at commands must be audited.
 ### Rationale
 Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. Audit records can be generated from various components within the information system (e.g., module or policy filter).
 
-### Aduit
+### Audit
 Verify the operating system generates audit records when successful/unsuccessful attempts to use the "open_by_handle_at" command occur. Check the file system rules in "/etc/audit/audit.rules" with the following commands:
 ```
 # grep -iw open_by_handle_at /etc/audit/audit.rules
@@ -668,7 +668,7 @@ Configure the operating system to generate audit records when successful/unsucce
 ```
 The audit daemon must be restarted for the changes to take effect.
 
-## 8.1.21 Recored Events that privileged-pasdsw command usage (Scored) 
+## 8.1.21 Recorded Events that privileged-pasdsw command usage (Scored) 
 
 ### Profile Applicability
 Level 4
@@ -679,7 +679,7 @@ All uses of the privileged-passwd commands must be audited.
 ### Rationale
 Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information. At a minimum, the organization must audit the full-text recording of privileged password commands. The organization must maintain audit trails in sufficient detail to reconstruct events to determine the cause and impact of compromise.
 
-### Aduit
+### Audit
 Verify the operating system generates audit records when successful/unsuccessful attempts to use the "privileged-passwd" commands occur. Check the file system rule in "/etc/audit/audit.rules" with the following command:
 ```
 # grep -i /usr/bin/passwd /etc/audit/audit.rules
@@ -703,7 +703,7 @@ Configure the operating system to generate audit records when successful/unsucce
 ```
 The audit daemon must be restarted for the changes to take effect.
 
-## 8.1.22 Recored Events that privileged-priv-change command usage (Scored) 
+## 8.1.22 Recorded Events that privileged-priv-change command usage (Scored) 
 
 ### Profile Applicability
 Level 4
@@ -714,7 +714,7 @@ All uses of the privileged-priv-change commands must be audited.
 ### Rationale
 Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information. At a minimum, the organization must audit the full-text recording of privileged access commands. The organization must maintain audit trails in sufficient detail to reconstruct events to determine the cause and impact of compromise.
 
-### Aduit
+### Audit
 Verify the operating system generates audit records when successful/unsuccessful attempts to use the "privileged-priv-change" commands occur. Check for the following system call being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules": 
 ```
 # grep -i /bin/su /etc/audit/audit.rules
@@ -741,7 +741,7 @@ Configure the operating system to generate audit records when successful/unsucce
 ```
 The audit daemon must be restarted for the changes to take effect.
 
-## 8.1.23 Recored Events that privileged-postfix commands usage (Scored) 
+## 8.1.23 Recorded Events that privileged-postfix commands usage (Scored) 
 
 ### Profile Applicability
 Level 4
@@ -752,7 +752,7 @@ All uses of the privileged-postfix commands must be audited.
 ### Rationale
 Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information. At a minimum, the organization must audit the full-text recording of privileged postfix commands. The organization must maintain audit trails in sufficient detail to reconstruct events to determine the cause and impact of compromise.
 
-### Aduit
+### Audit
 Verify the operating system generates audit records when successful/unsuccessful attempts to use the "privileged-postfix" commands occur.Check for the following system call being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules": 
 ```
 # grep -i /usr/sbin/postdrop /etc/audit/audit.rules
@@ -771,7 +771,7 @@ Configure the operating system to generate audit records when successful/unsucce
 
 The audit daemon must be restarted for the changes to take effect.
 
-## 8.1.24 Recored crontab command usage (scored) 
+## 8.1.24 Recorded crontab command usage (scored) 
 
 ### Profile Applicability
 Level 4
@@ -782,7 +782,7 @@ All uses of the crontab command must be audited.
 ### Rationale
 Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information. At a minimum, the organization must audit the full-text recording of privileged commands. The organization must maintain audit trails in sufficient detail to reconstruct events to determine the cause and impact of compromise.
 
-### Aduit
+### Audit
 Verify the operating system generates audit records when successful/unsuccessful attempts to use the "crontab" command occur. Check for the following system call being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules": 
 ```
 # grep -i /usr/bin/crontab /etc/audit/audit.rules
@@ -798,7 +798,7 @@ Configure the operating system to generate audit records when successful/unsucce
 
 The audit daemon must be restarted for the changes to take effect.
 
-## 8.1.25 Recored pam_timestamp_check command usage (scored) 
+## 8.1.25 Recorded pam_timestamp_check command usage (scored) 
 
 ### Profile Applicability
 Level 4
@@ -809,7 +809,7 @@ All uses of the pam_timestamp_check command must be audited.
 ### Rationale
 Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
 
-### Aduit
+### Audit
 Verify the operating system generates audit records when successful/unsuccessful attempts to use the "pam_timestamp_check" command occur. Check the auditing rules in "/etc/audit/audit.rules" with the following command:
 ```
 # grep -i "/sbin/pam_timestamp_check" /etc/audit/audit.rules
@@ -824,7 +824,7 @@ Fixtext: Configure the operating system to generate audit records when successfu
 ```
 The audit daemon must be restarted for the changes to take effect.
 
-## 8.1.26 Recored pam_tally/pam_tally2 command usage (scored)
+## 8.1.26 Recorded pam_tally/pam_tally2 command usage (scored)
 
 ### Profile Applicability
 Level 4
@@ -835,7 +835,7 @@ All uses of the pam_tally/pam_tally2 command must be audited.
 ### Rationale
 Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
 
-### Aduit
+### Audit
 Verify the operating system generates audit records when successful/unsuccessful attempts to use the "pam_tally/pam_tally2" command occur. Check the auditing rules in "/etc/audit/audit.rules" with the following command:
 ```
 # grep "/sbin/pam_tally[2]*" /etc/audit/audit.rules
@@ -863,7 +863,7 @@ Record events affecting the auditd, grub, fstab, pam, systectl configuration fil
 ### Rationale
 Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts.
 
-### Aduit
+### Audit
 Verify the operating system generates audit records that modify configuration. Check the auditing rules in "/etc/audit/audit.rules" with the following command:
 ```
 # grep "config_file_change" /etc/audit/audit.rules
@@ -902,7 +902,7 @@ Fixtext: Configure the operating system to generate audit records that modify co
 ```
 The audit daemon must be restarted for the changes to take effect.
 
-## 8.1.28 Recored setfacl and chacl commands usage (scored)
+## 8.1.28 Recorded setfacl and chacl commands usage (scored)
 
 ### Profile Applicability
 Level 4
@@ -913,7 +913,7 @@ All uses of the setfacl and chacl commands must be audited.
 ### Rationale
 Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. Audit records can be generated from various components within the information system (e.g., module or policy filter).
 
-### Aduit
+### Audit
 Verify the operating system generates an audit record when successful/unsuccessful attempts to use the "setfacl" and "chacl" command occur. Check that the following calls are being audited by performing the following command to check the file system rules in "/etc/audit/rules.d/audit.rules":
 ```
 $ sudo grep -w setfacl /etc/audit/rules.d/audit.rules
@@ -939,7 +939,7 @@ $ sudo systemctl restart auditd.service
 ```
 If The audit system is in immutable mode, the operating system  must be reboot for the changes to take effect.
 
-## 8.1.29 Recored usermod command usage (scored)
+## 8.1.29 Recorded usermod command usage (scored)
 
 ### Profile Applicability
 Level 4
@@ -950,7 +950,7 @@ All uses of the usermod command must be audited.
 ### Rationale
 Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. Audit records can be generated from various components within the information system (e.g., module or policy filter).
 
-### Aduit
+### Audit
 Verify that an audit event is generated for any successful/unsuccessful use of the "usermod" command. Check for the following system call being audited by performing the following command to check the file system rules in "/etc/audit/rules.d/audit.rules":
 ```
 $ sudo grep -w usermod /etc/audit/rules.d/audit.rules
@@ -971,7 +971,7 @@ $ sudo systemctl restart auditd.service
 ```
 If The audit system is in immutable mode, the operating system  must be reboot for the changes to take effect.
 
-## 8.1.30 Recored unix_update command usage (scored)
+## 8.1.30 Recorded unix_update command usage (scored)
 
 ### Profile Applicability
 Level 4
@@ -982,7 +982,7 @@ All uses of the usermod command must be audited.
 ### Rationale
 Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information. At a minimum, the organization must audit the full-text recording of privileged commands. The organization must maintain audit trails in sufficient detail to reconstruct events to determine the cause and impact of compromise. 
 
-### Aduit
+### Audit
 Verify that an audit event is generated for any successful/unsuccessful use of the "unix_update" command.\n\nCheck for the following system call being audited by performing the following command to check the file system rules in "/etc/audit/rules.d/audit.rules":
 ```
 $ sudo grep -w "unix_update" /etc/audit/rules.d/audit.rules
@@ -1012,7 +1012,7 @@ The audit system must be configured to audit the execution of privileged functio
 ### Rationale
 Misuse of privileged functions, either intentionally or unintentionally by authorized users, or by unauthorized external entities that have compromised information system accounts, is a serious and ongoing concern and can have significant adverse impacts on organizations. Auditing the use of privileged functions is one way to detect such misuse and identify the risk from insider threats and the advanced persistent threat.
 
-### Aduit
+### Audit
 Verify the operating system audits the execution of privilege functions. Check if the operating system is configured to audit the execution of the "execve" system call, by running the following command:
 ```
 $ sudo grep execve /etc/audit/rules.d/audit.rules
@@ -1048,7 +1048,7 @@ Without cryptographic integrity protections, system command and files can be alt
 ### Rationale
 Verify integrity all packages features to to monitor the files of the packages installed by the system.
 
-### Aduit
+### Audit
 Perform the following to determine(example):
 ```
 $ sudo dpkg -V 
@@ -1077,7 +1077,7 @@ When user at 3 times enter error password, returning error.
 ### Rationale 
 Prevent multiple attempts and guess the password. 
 
-### Aduit
+### Audit
 The "retry" option sets the number of attempt password times. Check for the value of the "retry" option in "/etc/pam.d/common-password" with the following command: 
 ```
 $ sudo grep retry /etc/pam.d/common-password 
@@ -1102,7 +1102,7 @@ Passwords must be a minimum of 14 characters in length.
 ### Rationale 
 The shorter the password, the lower the number of possible combinations that need to be tested before the password is compromised. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force Passwords are one factor of several that helps to determine strength and how long it takes to crack a password. Use of more characters in a password helps to exponentially increase the time and/or resources required to compromise the password.
 
-### Aduit
+### Audit
 Verify the operating system enforces a minimum 14-character password length. The "minlen" option sets the minimum number of characters in a new password. Check for the value of the "minlen" option in "/etc/pam.d/common-password " with the following command:
 ```
 $ sudo grep minlen /etc/pam.d/common-password 
@@ -1127,7 +1127,7 @@ When passwords are changed or new passwords are assigned, the new password must 
 ### Rationale 
 Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. Password complexity is one factor of several that determines how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised. 
 
-### Aduit
+### Audit
 The value to require a number of numeric characters to be set is expressed as a negative number in "/etc/pam.d/common-password ". Check the value for "dcredit" in "/etc/pam.d/common-password" with the following command:
 ```
 $ sudo grep dcredit /etc/pam.d/common-password  
@@ -1152,7 +1152,7 @@ When passwords are changed or new passwords are established, the new password mu
 ### Rationale 
 Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. Password complexity is one factor of several that determines how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised.
 
-### Aduit 
+### Audit 
 The value to require a number of upper-case characters to be set is expressed as a negative number in "/etc/pam.d/common-password". Check the value for "ucredit" in "/etc/pam.d/common-password" with the following command: 
 ```
 $ sudo grep ucredit /etc/pam.d/common-password 
@@ -1177,7 +1177,7 @@ When passwords are changed or new passwords are assigned, the new password must 
 ### Rationale 
 Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. Password complexity is one factor of several that determines how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised. 
 
-### Aduit 
+### Audit 
 Verify the operating system enforces password complexity by requiring that at least one special character be used. Note: The value to require a number of special characters to be set is expressed as a negative number in "/etc/pam.d/common-password". Check the value for "ocredit" in "/etc/pam.d/common-password" with the following command:
 ```
 $ sudo grep ocredit /etc/pam.d/common-password 
@@ -1202,7 +1202,7 @@ When passwords are changed or new passwords are established, the new password mu
 ### Rationale 
 Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. Password complexity is one factor of several that determines how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised.
 
-### Aduit
+### Audit
 The value to require a number of lower-case characters to be set is expressed as a negative number in "/etc/pam.d/common-password ". Check the value for "lcredit" in "/etc/pam.d/common-password " with the following command: 
 ```
 $ sudo grep lcredit /etc/pam.d/common-password 
@@ -1227,7 +1227,7 @@ When passwords are changed a minimum of eight of the total number of characters 
 ### Rationale 
 Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. Password complexity is one factor of several that determines how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised.
 
-### Aduit 
+### Audit 
 The "difok" option sets the number of characters in a password that must not be present in the old password. Check for the value of the "difok" option in "/etc/pam.d/common-password" with the following command:
 ```
 $ sudo grep difok /etc/pam.d/common-password 
@@ -1252,7 +1252,7 @@ When passwords are changed a minimum of four character classes must be changed.
 ### Rationale 
 Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. Password complexity is one factor of several that determines how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised.
  
-### Aduit
+### Audit
 The "minclass" option sets the minimum number of required classes of characters for the new password (digits, upper-case, lower-case, others). Check for the value of the "minclass" option in "/etc/pam.d/common-password" with the following command:
 ```
 $ sudo grep minclass /etc/pam.d/common-password
@@ -1277,7 +1277,7 @@ When passwords are changed the number of repeating consecutive characters must n
 ### Rationale 
 Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. Password complexity is one factor of several that determines how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised.
 
-### Aduit
+### Audit
 The "maxrepeat" option sets the maximum number of allowed same consecutive characters in a new password. Check for the value of the "maxrepeat" option in "/etc/pam.d/common-password" with the following command:
 ```
 $ sudo grep maxrepeat /etc/pam.d/common-password 
@@ -1302,7 +1302,7 @@ When passwords are changed the number of repeating characters of the same charac
 ### Rationale 
 Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. Password complexity is one factor of several that determines how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised. 
 
-### Aduit 
+### Audit 
 The "maxclassrepeat" option sets the maximum number of allowed same consecutive characters in the same class in the new password. Check for the value of the "maxclassrepeat" option in "/etc/pam.d/common-password" with the following command:
 ```
 $ sudo grep maxclassrepeat /etc/pam.d/common-password
@@ -1327,7 +1327,7 @@ Accounts subject to three unsuccessful logon attempts must be deny login.
 ### Rationale 
 By limiting the number of failed logon attempts, the risk of unauthorized system access via user password guessing, otherwise known as brute-forcing, is reduced. 
 
-### Aduit 
+### Audit 
 Check that the system deny an account for the maximum period after three unsuccessful logon attempts with the following command:
 ```
 $ sudo grep -w "^auth.*pam_tally2.so.*deny" /etc/pam.d/common-auth
@@ -1352,7 +1352,7 @@ The PAM system service must be configured to store only encrypted representation
 ### Rationale 
 Passwords need to be protected at all times, and encryption is the standard method for protecting passwords. If passwords are not encrypted, they can be plainly read (i.e., clear text) and easily compromised. Passwords encrypted with a weak algorithm are no more protected than if they are kept in plain text. 
 
-### Aduit 
+### Audit 
 Verify the PAM system service is configured to store only encrypted representations of passwords. The strength of encryption that must be used to hash passwords for all accounts is SHA512. Check that the system is configured to create SHA512 hashed passwords with the following command:
 ```
 $ sudo grep "password.*pam_unix.*sha512" /etc/pam.d/common-password    
@@ -1377,7 +1377,7 @@ The system must not have accounts configured with blank or null passwords.
 ### Rationale 
 If an account has an empty password, anyone could log on and run commands with the privileges of that account. Accounts with empty passwords should never be used in operational environments. 
 
-### Aduit 
+### Audit 
 To verify that null passwords cannot be used, run the following command: 
 ```
 $ sudo grep nullok /etc/pam.d/common-auth
@@ -1403,7 +1403,7 @@ The system must display the date and time of the last successful account logon u
 ### Rationale 
 Providing users with feedback on when account accesses last occurred facilitates user recognition and reporting of unauthorized account use.
 
-### Aduit 
+### Audit 
 Verify users are provided with feedback on when account accesses last occurred. Check that "pam_lastlog" is used and not silent with the following command:
 ```
 $ sudo grep pam_lastlog /etc/pam.d/login
@@ -1428,7 +1428,7 @@ Accounts subject to three unsuccessful login attempts must be set unlock_time fo
 ### Rationale 
 By limiting the number of failed login attempts, the risk of unauthorized system access via user password guessing, otherwise known as brute-forcing, is reduced. Limits are imposed by locking the account.
 
-### Aduit 
+### Audit 
 Check that the system unlock_time an account for the maximum period after three unsuccessful logon attempts with the following command:
 ```
 $ sudo grep -w "^auth.*pam_tally2.so.*unlock_time" /etc/pam.d/common-auth
@@ -1453,7 +1453,7 @@ Accounts subject to three unsuccessful root login attempts must be deny login.
 ### Rationale 
 By limiting the number of failed logon attempts, the risk of unauthorized system access via user password guessing, otherwise known as brute-forcing, is reduced. 
 
-### Aduit 
+### Audit 
 Check that the system deny an account for the maximum period after three unsuccessful logon attempts with the following command:
 ```
 $ sudo grep -w "^auth.*pam_tally2.so.*even_deny_root" /etc/pam.d/common-auth
@@ -1478,7 +1478,7 @@ The system must display the date and time of the last successful account logon u
 ### Rationale 
 Providing users with feedback on when account accesses via SSH last occurred facilitates user recognition and reporting of unauthorized account use.
 
-### Aduit 
+### Audit 
 Verify SSH provides users with feedback on when account accesses last occurred. Check that "PrintLastLog" keyword in the sshd daemon configuration file is used and set to "yes" with the following command:
 ```
 $ sudo grep -i printlastlog /etc/ssh/sshd_config
@@ -1504,7 +1504,7 @@ The SSH daemon must not allow authentication using known hosts authentication.
 ### Rationale 
 Configuring this setting for the SSH daemon provides additional assurance that remote logon via SSH will require a password, even in the event of misconfiguration elsewhere.
 
-### Aduit 
+### Audit 
 Verify the SSH daemon does not allow authentication using known hosts authentication. To determine how the SSH daemon's "IgnoreUserKnownHosts" option is set, run the following command:
 ```
 $ sudo grep -i IgnoreUserKnownHosts /etc/ssh/sshd_config
@@ -1530,7 +1530,7 @@ The SSH daemon must not permit Generic Security Service Application Program Inte
 ### Rationale 
 GSSAPI authentication is used to provide additional authentication mechanisms to applications. Allowing GSSAPI authentication through SSH exposes the systems GSSAPI to remote hosts, increasing the attack surface of the system. GSSAPI authentication must be disabled unless needed.
 
-### Aduit 
+### Audit 
 Verify the SSH daemon does not permit GSSAPI authentication unless approved. Check that the SSH daemon does not permit GSSAPI authentication with the following command:
 ```
 $ sudo grep -i gssapiauth /etc/ssh/sshd_config
@@ -1557,7 +1557,7 @@ The SSH daemon must not permit Kerberos authentication unless needed.
 ### Rationale 
 Kerberos authentication for SSH is often implemented using Generic Security Service Application Program Interface (GSSAPI). If Kerberos is enabled through SSH, the SSH daemon provides a means of access to the system's Kerberos implementation. Vulnerabilities in the system's Kerberos implementation may then be subject to exploitation. To reduce the attack surface of the system, the Kerberos authentication mechanism within SSH must be disabled for systems not using this capability.
 
-### Aduit 
+### Audit 
 Verify the SSH daemon does not permit Kerberos to authenticate passwords unless approved. Check that the SSH daemon does not permit Kerberos to authenticate passwords with the following command:
 ```
 $ sudo grep -i kerberosauth /etc/ssh/sshd_config
@@ -1583,7 +1583,7 @@ The SSH daemon must perform strict mode checking of home directory configuration
 ### Rationale 
 If other users have access to modify user-specific SSH configuration files, they may be able to log on to the system as another user.
 
-### Aduit 
+### Audit 
 Verify the SSH daemon performs strict mode checking of home directory configuration files. The location of the "sshd_config" file may vary if a different daemon is in use. Inspect the "sshd_config" file with the following command:
 ```
 $ sudo grep -i strictmodes /etc/ssh/sshd_config
@@ -1609,7 +1609,7 @@ The SSH daemon must use privilege separation.
 ### Rationale 
 SSH daemon privilege separation causes the SSH process to drop root privileges when not needed, which would decrease the impact of software vulnerabilities in the unprivileged section.
 
-### Aduit 
+### Audit 
 Verify the SSH daemon performs privilege separation. Check that the SSH daemon performs privilege separation with the following command:
 ```
 $ sudo grep -i usepriv /etc/ssh/sshd_config
@@ -1635,7 +1635,7 @@ The SSH daemon must not allow compression or must only allow compression after s
 ### Rationale 
 If compression is allowed in an SSH connection prior to authentication, vulnerabilities in the compression software could result in compromise of the system from an unauthenticated connection, potentially with root privileges.
 
-### Aduit 
+### Audit 
 Verify the SSH daemon performs compression after a user successfully authenticates. Check that the SSH daemon performs compression after a user successfully authenticates with the following command:
 ```
 $ sudo grep -i compression /etc/ssh/sshd_config
@@ -1661,7 +1661,7 @@ The SSH daemon must be configured to only use Message Authentication Codes (MACs
 ### Rationale 
 DoD information systems are required to use FIPS 140-2 approved cryptographic hash functions. The only SSHv2 hash algorithm meeting this requirement is SHA.
 
-### Aduit 
+### Audit 
 Verify the SSH daemon is configured to only use MACs employing FIPS 140-2-approved ciphers. Check that the SSH daemon is configured to only use MACs employing FIPS 140-2-approved ciphers with the following command:
 ```
 $ sudo grep -i macs /etc/ssh/sshd_config
@@ -1687,7 +1687,7 @@ The SSH public host key files must have mode 0644 or less permissive.
 ### Rationale 
 If a public host key file is modified by an unauthorized user, the SSH service may be compromised.
 
-### Aduit 
+### Audit 
 Verify the SSH public host key files have mode "0644" or less permissive. Note: SSH public key files may be found in other directories on the system depending on the installation. The following command will find all SSH public key files on the system:
 ```
 $ sudo find /etc/ssh/ -name "*key.pub" -perm /133 -exec ls -l {} \;
@@ -1713,7 +1713,7 @@ The SSH private host key files must have mode 0600 or less permissive.
 ### Rationale 
 If an unauthorized user obtains the private SSH host key file, the host could be impersonated.
 
-### Aduit 
+### Audit 
 Verify the SSH private host key files have mode "0600" or less permissive. Check the mode of the private host key files under "/etc/ssh" file with the following command:
 ```
 $ sudo find /etc/ssh/ -type f -name "*ssh_host*key" -exec ls -l {} \;
@@ -1741,7 +1741,7 @@ The shadow file must be configured to store only encrypted representations of pa
 ### Rationale
 Passwords need to be protected at all times, and encryption is the standard method for protecting passwords. If passwords are not encrypted, they can be plainly read (i.e., clear text) and easily compromised. Passwords encrypted with a weak algorithm are no more protected than if they are kept in plain text.
 
-### Aduit
+### Audit
 Verify the system's shadow file is configured to store only encrypted representations of passwords. The strength of encryption that must be used to hash passwords for all accounts is SHA512. Check that the system is configured to create SHA512 hashed passwords with the following command:
 ```
 $ sudo grep -i encrypt /etc/login.defs
@@ -1766,7 +1766,7 @@ Users must provide a password for privilege escalation.
 ### Rationale
 Without re-authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user re-authenticate. 
 
-### Aduit
+### Audit
 If passwords are not being used for authentication, this is Not Applicable. Verify the operating system requires users to supply a password for privilege escalation. Check the configuration of the "/etc/sudoers" and "/etc/sudoers.d/*" files with the following command: 
 ```
 $ sudo grep -i nopasswd /etc/sudoers /etc/sudoers.d/*
@@ -1787,7 +1787,7 @@ Users must re-authenticate for privilege escalation.
 ### Rationale
 Without re-authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user reauthenticate.
 
-### Aduit
+### Audit
 Verify the operating system requires users to reauthenticate for privilege escalation. Check the configuration of the "/etc/sudoers" and "/etc/sudoers.d/*" files with the following command:
 ```
 $ sudo grep -i authenticate /etc/sudoers /etc/sudoers.d/*
@@ -1808,7 +1808,7 @@ The delay between logon prompts following a failed console logon attempt must be
 ### Rationale
 Configuring the operating system to implement organization-wide security implementation guides and security checklists verifies compliance with federal standards and establishes a common security baseline across DoD that reflects the most restrictive security posture consistent with operational requirements. Configuration settings are the set of parameters that can be changed in hardware, software, or firmware components of the system that affect the security posture and/or functionality of the system. Security-related parameters are those parameters impacting the security state of the system, including the parameters required to satisfy other security control requirements. Security-related parameters include, for example, registry settings; account, file, and directory permission settings; and settings for functions, ports, protocols, services, and remote connections.
 
-### Aduit
+### Audit
 Verify the operating system enforces a delay of at least four seconds between console logon prompts following a failed logon attempt. Check the value of the "delay" parameter in the "/etc/pam.d/login" file with the following command:
 ```
 $ sudo grep -i delay /etc/pam.d/login
@@ -1833,7 +1833,7 @@ All local interactive user accounts, upon creation, must be assigned a home dire
 ### Rationale
 If local interactive users are not assigned a valid home directory, there is no place for the storage and control of files they should own.
 
-### Aduit
+### Audit
 Verify all local interactive users on the system are assigned a home directory upon creation. Check to see if the system is configured to create home directories for local interactive users with the following command:
 ```
 $ sudo grep -i create_home /etc/login.defs
@@ -1858,7 +1858,7 @@ The operating system must limit the number of concurrent sessions to 10 for all 
 ### Rationale
 Operating system management includes the ability to control the number of users and user sessions that utilize an operating system. Limiting the number of allowed users and sessions per user is helpful in reducing the risks related to DoS attacks. This requirement addresses concurrent sessions for information system accounts and does not address concurrent sessions by single users via multiple system accounts. The maximum number of concurrent sessions should be defined based on mission needs and the operational environment for each system.
 
-### Aduit
+### Audit
 Verify the operating system limits the number of concurrent sessions to "10" for all accounts and/or account types by issuing the following command:
 ```
 $ sudo grep "maxlogins" /etc/security/limits.conf
@@ -1883,7 +1883,7 @@ There must be no .shosts and shosts.equiv files on the system.
 ### Rationale
 The .shosts and shosts.equiv files are used to configure host-based authentication for individual users or the system via SSH. Host-based authentication is not sufficient for preventing unauthorized access to the system, as it does not require interactive identification and authentication of a connection request, or for the use of two-factor authentication.
 
-### Aduit
+### Audit
 Verify there are no ".shosts" and "shosts.equiv" files on the system. Check the system for the existence of these files with the following command:
 ```
 $ sudo find / -name .shosts
@@ -1909,7 +1909,7 @@ All network connections associated with a communication session must be terminat
 ### Rationale
 Terminating an idle session within a short time period reduces the window of opportunity for unauthorized personnel to take control of a management session enabled on the console or console port that has been left unattended. In addition, quickly terminating an idle session will also free up resources committed by the managed network element. Terminating network connections associated with communications sessions includes, for example, de-allocating associated TCP/IP address/port pairs at the operating system level and de-allocating networking assignments at the application level if multiple application sessions are using a single operating system-level network connection. This does not mean that the operating system terminates all sessions or network access; it only ends the inactive session and releases the resources associated with that session. 
 
-### Aduit
+### Audit
 Verify the operating system terminates all network connections associated with a communications session at the end of the session or based on inactivity. Check the value of the system inactivity timeout with the following command: 
 ```
 $ sudo grep -i tmout /etc/bashrc /etc/profile.d/*

--- a/docs/use-cases/apache2-usecase/etc.iptables.rules.v4.4http.sh
+++ b/docs/use-cases/apache2-usecase/etc.iptables.rules.v4.4http.sh
@@ -13,7 +13,7 @@ IPT="/sbin/iptables"
   
 PUB_IFS="eth0"
    
-# DROP all incomming traffic
+# DROP all incoming traffic
 $IPT -P INPUT DROP
 $IPT -P OUTPUT DROP
 $IPT -P FORWARD DROP
@@ -70,7 +70,7 @@ do
     $IPT -I INPUT -p tcp --dport 22 -i ${PUB_IF} -m state --state NEW -m recent --set
     $IPT -I INPUT -p tcp --dport 22 -i ${PUB_IF} -m state --state NEW -m recent  --update --seconds 60 --hitcount 4 -j LOGDROP
  done
-    # Allow full outgoing connection but no incomming stuff
+    # Allow full outgoing connection but no incoming stuff
     $IPT -A INPUT -p icmp -m icmp --icmp-type 4 -j ACCEPT
     $IPT -A OUTPUT -p icmp -m icmp --icmp-type 8 -j ACCEPT
 

--- a/docs/use-cases/nodejs-redis-mysql-usecase/README.md
+++ b/docs/use-cases/nodejs-redis-mysql-usecase/README.md
@@ -55,7 +55,7 @@ and update
 
 #### Configurate Redis
 
-modify `/etc/redis/redis.conf`, changce supervised no to 
+modify `/etc/redis/redis.conf`, chance supervised no to 
 
 ```
 supervised systemd

--- a/docs/use-cases/nodejs-redis-mysql-usecase/README.md
+++ b/docs/use-cases/nodejs-redis-mysql-usecase/README.md
@@ -55,7 +55,7 @@ and update
 
 #### Configurate Redis
 
-modify `/etc/redis/redis.conf`, chance supervised no to 
+modify `/etc/redis/redis.conf`, change supervised no to 
 
 ```
 supervised systemd

--- a/docs/use-cases/nodejs-redis-mysql-usecase/helloworld/services/SqlService.js
+++ b/docs/use-cases/nodejs-redis-mysql-usecase/helloworld/services/SqlService.js
@@ -27,7 +27,7 @@ class SqlService {
 		//if exist database
 		await this.init_database();
 		//if exist table
-		let querys = [
+		let queries = [
 			{
 				tableName: 'test',
 				sqls: [
@@ -36,7 +36,7 @@ class SqlService {
 				]
 			},
 		]
-		await this.init_tables(querys);
+		await this.init_tables(queries);
 	}
 
 	//init database

--- a/etc/hardening.cfg
+++ b/etc/hardening.cfg
@@ -4,7 +4,7 @@
 # Valid values are debug info ok warning error
 LOGLEVEL=info
 
-# Backup directory, every file modified by hardening will be backuped here, with versionning
+# Backup directory, every file modified by hardening will be backuped here, with versioning
 # Means that if a file is modified more than once during the process, you will have hardening step diffs in the folder
 BACKUPDIR="$CIS_ROOT_DIR/tmp/backups"
 

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -20,7 +20,7 @@ is_centos_8()
 	fi
 }
 
-# return 9 if it is debian9, return 10 if it is debian10, reutrn 11 if it is debian11, return 12 if it is debian12, return 13 if it is debian13, return 1 if it is less than 9
+# return 9 if it is debian9, return 10 if it is debian10, return 11 if it is debian11, return 12 if it is debian12, return 13 if it is debian13, return 1 if it is less than 9
 get_debian_ver()
 {
 	DEBIAN13CODENAME="trixie"
@@ -477,7 +477,7 @@ is_service_active() {
 	fi
     if [ $FNRET = 0 ]; then
         if [ $(systemctl is-active $SERVICE | grep -c "^active") -eq 1 ]; then
-            debug "Service $SERVICE is actived"
+            debug "Service $SERVICE is active"
             FNRET=0
         else
             debug "Service $SERVICE is inactived"
@@ -830,7 +830,7 @@ verify_integrity_all_packages()
 	fi
 }
 
-# Check paramer with str
+# Check parameter with str
 # example: Storage=persistent
 # return: 0 1 2 3 
 check_param_pair_by_str ()
@@ -878,7 +878,7 @@ reset_option_str_to_journald ()
     sed -i "s/${OPTION}=.*/${OPTION}=${SET_OPSTR}/" $FILENAME
 }
 
-# Check paramer with value 
+# Check parameter with value 
 # example : minlen = 9
 # ruturn: 0  1  2  3 
 check_param_pair_by_value ()
@@ -1370,7 +1370,7 @@ check_audit_path ()
 # Reference: https://access.redhat.com/solutions/3906701 
 tcp_wrappers_warn ()
 {
-	warn "The package(tcp_wrappers) has been deprecated in RHEL 7 and therefore it will not be avaliable in RHEL 8 or later RHEL release."
+	warn "The package(tcp_wrappers) has been deprecated in RHEL 7 and therefore it will not be available in RHEL 8 or later RHEL release."
 }
 
 
@@ -1415,7 +1415,7 @@ check_aa_status ()
 }
 
 # Check sshd access limit 
-# If not exist key of above, it's fail beacause default is everyone to allow 
+# If not exist key of above, it's fail because default is everyone to allow 
 # Example: $1='AllowUsers'  $2='AllowUsers[[:space:]]*\*'
 check_sshd_access_limit ()
 {
@@ -1435,7 +1435,7 @@ check_sshd_access_limit ()
 
 # Check sshd conf for one value  sshd -T return 'keyword value' pairs
 # If the value of keyword is equal $2, return 0 
-# If the keywork does not exist in the sshd runtime configuration, return 1
+# If the keyword does not exist in the sshd runtime configuration, return 1
 # If the value of keyword is not equal $2, return 2
 # Example: $1='PermitRootLogin'  $2='no'
 check_sshd_conf_for_one_value_runtime ()


### PR DESCRIPTION
  This PR cleans up repository-wide spelling issues reported by typos and improves the readability of the Mandarin
  documentation in README-CN.md.

  ## Changes

  - fix [typos](https://github.com/crate-ci/typos) findings across docs, shell scripts, comments, and user-facing log strings
  - normalize several awkward English status messages such as service state and summary labels
  - improve Mandarin wording in README-CN.md for clarity and natural readability
  - keep commands, links, and technical behavior unchanged

  ## Notes

  - the Chinese README was edited with a readability focus, not a full structural rewrite
  - English-only sections in README-CN.md such as license/disclaimer text were left as-is
